### PR TITLE
Issue21 Enhance visualization to show call stack 

### DIFF
--- a/PythonVisualizations/Array.py
+++ b/PythonVisualizations/Array.py
@@ -275,9 +275,54 @@ class Array(VisualizationApp):
         super().cleanUp(*args, **kwargs) # Do the VisualizationApp clean up
         self.fixCells()       # Restore cells to their coordinates in array
 
+    def traverse(self):
+        self.cleanUp()
+
+        # draw an index pointing to the first cell
+        indexDisplay = self.createIndex(0, 'j')
+        self.cleanup |= set(indexDisplay)
+
+        # draw output box
+        canvasDimensions = self.widgetDimensions(self.canvas)
+        spacing = CELL_SIZE * 3 // 4
+        padding = 10
+        outputBox = self.canvas.create_rectangle(
+            (canvasDimensions[0] - len(self.list) * spacing - padding) // 2,
+            canvasDimensions[1] - CELL_SIZE - padding,
+            (canvasDimensions[0] + len(self.list) * spacing + padding) // 2,
+            canvasDimensions[1] - padding,
+            fill = OPERATIONS_BG)
+        self.cleanup.add(outputBox)
+
+        for j in range(len(self.list)):
+            # calculate where the value will need to move to
+            outputBoxCoords = self.canvas.coords(outputBox)
+            midOutputBox = (outputBoxCoords[3] + outputBoxCoords[1]) // 2
+
+            # create the value to move to output box
+            valueOutput = self.copyCanvasItem(self.list[j].display_val)
+            valueList = (valueOutput,)
+            self.cleanup.add(valueOutput)
+
+            # move value to output box
+            toPositions = (outputBoxCoords[0] + padding/2 + (j+1/2)*spacing, midOutputBox)
+            self.moveItemsTo(valueList, (toPositions,), sleepTime=.02)
+
+            # make the value 25% smaller
+            newSize = (VALUE_FONT[0], int(VALUE_FONT[1]*.75))
+            self.canvas.itemconfig(valueOutput, font=newSize)
+            self.window.update()
+
+            # wait and then move the index pointer over
+            self.wait(0.2)
+            self.moveItemsBy(indexDisplay, (CELL_SIZE, 0), sleepTime=0.03)
+            
+
     def makeButtons(self):
         vcmd = (self.window.register(numericValidate),
                 '%d', '%i', '%P', '%s', '%S', '%v', '%V', '%W')
+        traverseButton = self.addOperation(
+            "Traverse", lambda: self.traverse())
         findButton = self.addOperation(
             "Find", lambda: self.clickFind(), numArguments=1,
             validationCmd=vcmd)
@@ -292,7 +337,7 @@ class Array(VisualizationApp):
         #this makes the pause, play and stop buttons 
         self.addAnimationButtons()
         return [findButton, insertButton, deleteValueButton,
-                deleteRightmostButton]
+                deleteRightmostButton, traverseButton]
 
     def validArgument(self):
         entered_text = self.getArgument()

--- a/PythonVisualizations/Array.py
+++ b/PythonVisualizations/Array.py
@@ -274,23 +274,24 @@ class Array(VisualizationApp):
         self.fixCells()       # Restore cells to their coordinates in array
 
     def traverse(self):
-        self.cleanUp()
+        callEnviron = self.createCallEnvironment()
+        self.startAnimations()
 
         # draw an index pointing to the first cell
         indexDisplay = self.createIndex(0, 'j')
-        self.cleanup |= set(indexDisplay)
+        callEnviron |= set(indexDisplay)
 
         # draw output box
         canvasDimensions = self.widgetDimensions(self.canvas)
-        spacing = CELL_SIZE * 3 // 4
+        spacing = self.CELL_SIZE * 3 // 4
         padding = 10
         outputBox = self.canvas.create_rectangle(
             (canvasDimensions[0] - len(self.list) * spacing - padding) // 2,
-            canvasDimensions[1] - CELL_SIZE - padding,
+            canvasDimensions[1] - self.CELL_SIZE - padding,
             (canvasDimensions[0] + len(self.list) * spacing + padding) // 2,
             canvasDimensions[1] - padding,
-            fill = OPERATIONS_BG)
-        self.cleanup.add(outputBox)
+            fill = self.OPERATIONS_BG)
+        callEnviron.add(outputBox)
 
         for j in range(len(self.list)):
             # calculate where the value will need to move to
@@ -300,64 +301,23 @@ class Array(VisualizationApp):
             # create the value to move to output box
             valueOutput = self.copyCanvasItem(self.list[j].display_val)
             valueList = (valueOutput,)
-            self.cleanup.add(valueOutput)
+            callEnviron.add(valueOutput)
 
             # move value to output box
-            toPositions = (outputBoxCoords[0] + padding/2 + (j+1/2)*spacing, midOutputBox)
+            toPositions = (outputBoxCoords[0] + padding/2 + (j + 1/2)*spacing, 
+                           midOutputBox)
             self.moveItemsTo(valueList, (toPositions,), sleepTime=.02)
 
             # make the value 25% smaller
-            newSize = (VALUE_FONT[0], int(VALUE_FONT[1]*.75))
+            newSize = (self.VALUE_FONT[0], int(self.VALUE_FONT[1] * .75))
             self.canvas.itemconfig(valueOutput, font=newSize)
             self.window.update()
 
             # wait and then move the index pointer over
             self.wait(0.2)
-            self.moveItemsBy(indexDisplay, (CELL_SIZE, 0), sleepTime=0.03)
-            
+            self.moveItemsBy(indexDisplay, (self.CELL_SIZE, 0), sleepTime=0.03)
 
-    def traverse(self):
-        self.cleanUp()
-
-        # draw an index pointing to the first cell
-        indexDisplay = self.createIndex(0, 'j')
-        self.cleanup |= set(indexDisplay)
-
-        # draw output box
-        canvasDimensions = self.widgetDimensions(self.canvas)
-        spacing = CELL_SIZE * 3 // 4
-        padding = 10
-        outputBox = self.canvas.create_rectangle(
-            (canvasDimensions[0] - len(self.list) * spacing - padding) // 2,
-            canvasDimensions[1] - CELL_SIZE - padding,
-            (canvasDimensions[0] + len(self.list) * spacing + padding) // 2,
-            canvasDimensions[1] - padding,
-            fill = OPERATIONS_BG)
-        self.cleanup.add(outputBox)
-
-        for j in range(len(self.list)):
-            # calculate where the value will need to move to
-            outputBoxCoords = self.canvas.coords(outputBox)
-            midOutputBox = (outputBoxCoords[3] + outputBoxCoords[1]) // 2
-
-            # create the value to move to output box
-            valueOutput = self.copyCanvasItem(self.list[j].display_val)
-            valueList = (valueOutput,)
-            self.cleanup.add(valueOutput)
-
-            # move value to output box
-            toPositions = (outputBoxCoords[0] + padding/2 + (j+1/2)*spacing, midOutputBox)
-            self.moveItemsTo(valueList, (toPositions,), sleepTime=.02)
-
-            # make the value 25% smaller
-            newSize = (VALUE_FONT[0], int(VALUE_FONT[1]*.75))
-            self.canvas.itemconfig(valueOutput, font=newSize)
-            self.window.update()
-
-            # wait and then move the index pointer over
-            self.wait(0.2)
-            self.moveItemsBy(indexDisplay, (CELL_SIZE, 0), sleepTime=0.03)
-            
+        self.cleanUp(callEnviron)
 
     def makeButtons(self):
         vcmd = (self.window.register(numericValidate),

--- a/PythonVisualizations/SimpleSorting.py
+++ b/PythonVisualizations/SimpleSorting.py
@@ -167,9 +167,8 @@ def insert(self, item):
     
     def insert(self, val):
         self.startAnimations()
-        self.cleanUp()
-        self.showCode(self.insertCode.strip())
-        self.createCodeTags(self.insertCodeSnippets)
+        callEnviron = self.createCallEnvironment(
+            self.insertCode.strip(), self.insertCodeSnippets)
         
         # If array needs to grow, add cells:
         while self.size < len(self.list) + 1:
@@ -177,9 +176,9 @@ def insert(self, item):
             self.createArrayCell(len(self.list))
 
         # draw an index pointing to the last cell
-        self.highlightCodeTags('item_assignment')
+        self.highlightCodeTags('item_assignment', callEnviron)
         indexDisplay = self.createIndex(len(self.list), 'nItems')
-        self.cleanup |= set(indexDisplay)
+        callEnviron |= set(indexDisplay)
 
         # create new cell and cell value display objects
         toPositions = (self.cellCoords(len(self.list)), 
@@ -198,15 +197,14 @@ def insert(self, item):
             val, self.canvas.itemconfigure(cellPair[0], 'fill'), *cellPair))
 
         # advance index for next insert
-        self.highlightCodeTags('nitem_increment')
+        self.highlightCodeTags('nitem_increment', callEnviron)
         self.moveItemsBy(indexDisplay, (CELL_SIZE, 0), sleepTime=0.01)
 
-        self.highlightCodeTags([])
+        self.highlightCodeTags([], callEnviron)
         self.stopAnimations()
+        self.cleanUp(callEnviron)
 
     def removeFromEnd(self):
-        self.cleanUp()
-        
         # pop an Element from the list
         if len(self.list) == 0:
             self.setMessage('Array is empty!')
@@ -303,30 +301,29 @@ def find(self, item):
     
     def find(self, val):
         self.startAnimations()
-        self.cleanUp()
-        self.showCode(self.findCode.strip())
-        self.createCodeTags(self.findCodeSnippets)
+        callEnviron = self.createCallEnvironment(
+            self.findCode.strip(), self.findCodeSnippets)
 
         # draw an index for variable j pointing to the first cell
         indexDisplay = self.createIndex(0, 'j')
-        self.cleanup |= set(indexDisplay)
+        callEnviron |= set(indexDisplay)
 
         # go through each Drawable in the list
         for i in range(len(self.list)):
             n = self.list[i]
 
             # if the value is found
-            self.highlightCodeTags('key_comparison')
+            self.highlightCodeTags('key_comparison', callEnviron)
             self.window.update()
             if self.wait(0.1):
                 break
             if n.val == val:
                 # get the position of the displayed cell and val
-                self.highlightCodeTags('key_found')
+                self.highlightCodeTags('key_found', callEnviron)
                 posShape = self.canvas.coords(n.display_shape)
                 
                 # Highlight the found element with a circle
-                self.cleanup.add(self.canvas.create_oval(
+                callEnviron.add(self.canvas.create_oval(
                     *add_vector(
                         posShape,
                         (CELL_BORDER, CELL_BORDER, -CELL_BORDER, -CELL_BORDER)),
@@ -337,29 +334,31 @@ def find(self, item):
                 self.wait(0.1)
                 
                 # Animation stops
-                self.highlightCodeTags([])
+                self.highlightCodeTags([], callEnviron)
                 self.stopAnimations()
+                self.cleanUp(callEnviron)
                 return i
 
             # if not found, then move the index over one cell
-            self.highlightCodeTags('outer_loop_increment')
+            self.highlightCodeTags('outer_loop_increment', callEnviron)
             self.moveItemsBy(indexDisplay, (CELL_SIZE, 0), sleepTime=0.01)
             if self.wait(0.01):
                 break
 
         # Key not found
-        self.highlightCodeTags('key_not_found')
+        self.highlightCodeTags('key_not_found', callEnviron)
         self.window.update()
         self.wait(0.1)
         
         # Animation stops
-        self.highlightCodeTags([])
+        self.highlightCodeTags([], callEnviron)
         self.stopAnimations()
+        self.cleanUp(callEnviron)
         return None
 
     def shuffle(self):
         self.startAnimations()
-        self.cleanUp()
+        callEnviron = self.createCallEnvironment()
 
         y = ARRAY_Y0
         for i in range(len(self.list)):
@@ -397,6 +396,7 @@ def find(self, item):
 
         # Animation stops
         self.stopAnimations()
+        self.cleanUp(callEnviron)
 
     insertionSortCode = """
 def insertionSort(self):
@@ -421,43 +421,43 @@ def insertionSort(self):
     # SORTING METHODS
     def insertionSort(self):
         self.startAnimations()
-        self.cleanUp()
-        self.showCode(SimpleArraySort.insertionSortCode.strip())
-        self.createCodeTags(self.insertionSortCodeSnippets)
+        callEnviron = self.createCallEnvironment(
+            SimpleArraySort.insertionSortCode.strip(),
+            self.insertionSortCodeSnippets)
         n = len(self.list)
 
         # make an index arrow for the outer loop
         outer = 1
         outerIndex = self.createIndex(outer, "outer", level=-2)
-        self.cleanup |= set(outerIndex)
-        self.highlightCodeTags('outer_loop_increment')
+        callEnviron |= set(outerIndex)
+        self.highlightCodeTags('outer_loop_increment', callEnviron)
 
         # make an index arrow that points to the next cell to check
         innerIndex = self.createIndex(outer, "inner", level=-1)
-        self.cleanup |= set(innerIndex)
+        callEnviron |= set(innerIndex)
         tempVal, label = None, None
 
         # All items beyond the outer index have not been sorted
         while outer < len(self.list):
-            self.highlightCodeTags('outer_loop_increment')
+            self.highlightCodeTags('outer_loop_increment', callEnviron)
 
             # Store item at outer index in temporary mark variable
             temp = self.list[outer].val
-            self.highlightCodeTags('temp_assignment')
+            self.highlightCodeTags('temp_assignment', callEnviron)
             if tempVal:
                 tempVal, _ = self.assignToTemp(
                     outer, varName="temp", existing=label)
             else:
                 tempVal, label = self.assignToTemp(outer, varName="temp")
-                self.cleanup.add(label)
-            self.cleanup.add(tempVal.display_shape)
-            self.cleanup.add(tempVal.display_val)
+                callEnviron.add(label)
+            callEnviron.add(tempVal.display_shape)
+            callEnviron.add(tempVal.display_val)
 
             # Inner loop starts at marked temporary item
             inner = outer 
 
             # Move inner index arrow to point at cell to check
-            self.highlightCodeTags('inner_assignment')
+            self.highlightCodeTags('inner_assignment', callEnviron)
             centerX0 = self.cellCenter(inner)[0]
             deltaX = centerX0 - self.canvas.coords(innerIndex[0])[0]
             if deltaX != 0:
@@ -465,17 +465,17 @@ def insertionSort(self):
                 
             # Loop down until we find an item less than or equal to the mark
             while inner > 0 and temp < self.list[inner - 1].val:
-                self.highlightCodeTags('inner_loop_test')
+                self.highlightCodeTags('inner_loop_test', callEnviron)
                 if self.wait(0.05):
                     break
 
                 # Shift cells right that are greater than mark
-                self.highlightCodeTags('inner_loop_assignment')
+                self.highlightCodeTags('inner_loop_assignment', callEnviron)
                 self.assignElement(inner - 1, inner)
 
                 # Move inner index arrow to point at next cell to check
                 inner -= 1
-                self.highlightCodeTags('inner_loop_decrement')
+                self.highlightCodeTags('inner_loop_decrement', callEnviron)
                 centerX0 = self.cellCenter(inner)[0]
                 deltaX = centerX0 - self.canvas.coords(innerIndex[0])[0]
                 if deltaX != 0:
@@ -486,26 +486,27 @@ def insertionSort(self):
                 break
             
             # Copy marked temporary value to insetion point
-            self.highlightCodeTags('outer_loop_assignment')
+            self.highlightCodeTags('outer_loop_assignment', callEnviron)
             self.assignFromTemp(inner, tempVal, None)
 
             # Take it out of the cleanup set since it should persist
             for item in (tempVal.display_shape, tempVal.display_val):
-                if item in self.cleanup:
-                    self.cleanup.remove(item)
+                if item in callEnviron:
+                    callEnviron.remove(item)
 
             # Advance outer loop
             outer += 1
-            self.highlightCodeTags('outer_loop_increment')
+            self.highlightCodeTags('outer_loop_increment', callEnviron)
             self.moveItemsBy(outerIndex, (CELL_SIZE, 0), sleepTime=0.02)
             if self.wait(0.01):
                 break
 
-        self.highlightCodeTags([])
+        self.highlightCodeTags([], callEnviron)
         self.fixCells()
 
         # Animation stops
         self.stopAnimations()
+        self.cleanUp(callEnviron)
 
     bubbleSortCode = """
 def bubbleSort(self):
@@ -523,38 +524,38 @@ def bubbleSort(self):
     
     def bubbleSort(self):
         self.startAnimations()
-        self.cleanUp()
-        self.showCode(SimpleArraySort.bubbleSortCode.strip())
-        self.createCodeTags(self.bubbleSortCodeSnippets)
+        callEnviron = self.createCallEnvironment(
+            SimpleArraySort.bubbleSortCode.strip(),
+            self.bubbleSortCodeSnippets)
         n = len(self.list)
 
         # make an index arrow that points to last unsorted element
         last = n - 1
         lastIndex = self.createIndex(last, "last", level=2)
-        self.cleanup |= set(lastIndex)
-        self.highlightCodeTags('outer_loop_increment')
+        callEnviron |= set(lastIndex)
+        self.highlightCodeTags('outer_loop_increment', callEnviron)
 
         # make an index arrow that points to the next cell to check
         innerIndex = self.createIndex(0, "inner", level=1)
-        self.cleanup |= set(innerIndex)
+        callEnviron |= set(innerIndex)
         
         # While unsorted cells remain
         while last > 0:
             for inner in range(last):
                 # Move inner index arrow to cell to check
-                self.highlightCodeTags('inner_loop_increment')
+                self.highlightCodeTags('inner_loop_increment', callEnviron)
                 centerX0 = self.cellCenter(inner)[0]
                 deltaX = centerX0 - self.canvas.coords(innerIndex[0])[0]
                 if deltaX != 0:
                     self.moveItemsBy(innerIndex, (deltaX, 0), sleepTime=0.02)
                     
                 # Compare cell value at inner index with the next value
-                self.highlightCodeTags('inner_loop_comparison')
+                self.highlightCodeTags('inner_loop_comparison', callEnviron)
                 self.window.update()
                 if self.wait(0.2):
                     break
                 if self.list[inner].val > self.list[inner+1].val:
-                    self.highlightCodeTags('inner_loop_swap')
+                    self.highlightCodeTags('inner_loop_swap', callEnviron)
                     self.swap(inner, inner+1)
 
             if self.wait(0.01):
@@ -562,12 +563,13 @@ def bubbleSort(self):
 
             # move last index one lower
             last -= 1
-            self.highlightCodeTags('outer_loop_increment')
+            self.highlightCodeTags('outer_loop_increment', callEnviron)
             self.moveItemsBy(lastIndex, (-CELL_SIZE, 0), sleepTime=0.05)
 
         # Animation stops
-        self.highlightCodeTags([])
+        self.highlightCodeTags([], callEnviron)
         self.stopAnimations()
+        self.cleanUp(callEnviron)
 
     selectionSortCode = """
 def selectionSort(self):
@@ -589,27 +591,27 @@ def selectionSort(self):
     
     def selectionSort(self):
         self.startAnimations()
-        self.cleanUp()
-        self.showCode(SimpleArraySort.selectionSortCode.strip())
-        self.createCodeTags(self.selectionSortCodeSnippets)
+        callEnviron = self.createCallEnvironment(
+            SimpleArraySort.selectionSortCode.strip(),
+            self.selectionSortCodeSnippets)
         n = len(self.list)
 
         # make an index arrow for the outer loop
         outer = 0
         outerIndex = self.createIndex(outer, "outer", level=3)
-        self.cleanup |= set(outerIndex)
-        self.highlightCodeTags('outer_loop_increment')
+        callEnviron |= set(outerIndex)
+        self.highlightCodeTags('outer_loop_increment', callEnviron)
 
         # make an index arrow that points to the next cell to check
         innerIndex = self.createIndex(outer+1, "inner", level=1)
-        self.cleanup |= set(innerIndex)
+        callEnviron |= set(innerIndex)
         minIndex = None
 
         # All items beyond the outer index have not been sorted
         while outer < len(self.list) - 1:
 
             min_idx = outer
-            self.highlightCodeTags('outer_min_assignment')
+            self.highlightCodeTags('outer_min_assignment', callEnviron)
             if minIndex:
                 self.moveItemsBy(
                     minIndex,
@@ -619,26 +621,26 @@ def selectionSort(self):
                 minIndex = self.createIndex(outer, "min", level=2)
                 if self.wait(0.1):
                     break
-                self.cleanup |= set(minIndex)
+                callEnviron |= set(minIndex)
             
             # Find the minimum element in remaining
             # unsorted array
             for inner in range(outer + 1, len(self.list)):
                 
                 # Move inner index arrow to point at cell to check
-                self.highlightCodeTags('inner_loop_increment')
+                self.highlightCodeTags('inner_loop_increment', callEnviron)
                 centerX0 = self.cellCenter(inner)[0]
                 deltaX = centerX0 - self.canvas.coords(innerIndex[0])[0]
                 if deltaX != 0:
                     self.moveItemsBy(innerIndex, (deltaX, 0), sleepTime=0.02)
 
-                self.highlightCodeTags('inner_loop_comparison')
+                self.highlightCodeTags('inner_loop_comparison', callEnviron)
                 self.window.update()
                 if self.wait(0.2):
                     break
                 if self.list[inner].val < self.list[min_idx].val:
                     min_idx = inner
-                    self.highlightCodeTags('inner_min_assignment')
+                    self.highlightCodeTags('inner_min_assignment', callEnviron)
                     self.moveItemsBy(
                         minIndex,
                         (self.canvas.coords(innerIndex[0])[0] -
@@ -648,19 +650,20 @@ def selectionSort(self):
                 break
 
             # Swap the found minimum element with the one indexed by outer
-            self.highlightCodeTags('outer_loop_swap')
+            self.highlightCodeTags('outer_loop_swap', callEnviron)
             self.swap(outer, min_idx)
             
             # move outer index one higher
             outer += 1
-            self.highlightCodeTags('outer_loop_increment')
+            self.highlightCodeTags('outer_loop_increment', callEnviron)
             self.moveItemsBy(outerIndex, (CELL_SIZE, 0), sleepTime=0.05)
 
         self.fixCells()
 
         # Animation stops
-        self.highlightCodeTags([])
+        self.highlightCodeTags([], callEnviron)
         self.stopAnimations()
+        self.cleanUp(callEnviron)
         
     def stopMergeSort(self, toX=ARRAY_X0, toY=ARRAY_Y0):
         # bring all cells up to original position
@@ -705,8 +708,8 @@ def selectionSort(self):
             self.canvas.coords(drawItem.display_val, *self.cellCenter(i))
         self.window.update()
 
-    def cleanUp(self):        # Customize clean up for sorting
-        super().cleanUp()     # Do the VisualizationApp clean up
+    def cleanUp(self, *args): # Customize clean up for sorting
+        super().cleanUp(*args) # Do the VisualizationApp clean up
         self.fixCells()       # Restore cells to their coordinates in array
         
     def makeButtons(self):

--- a/PythonVisualizations/SimpleSorting.py
+++ b/PythonVisualizations/SimpleSorting.py
@@ -202,7 +202,6 @@ def insert(self, item):
         self.moveItemsBy(indexDisplay, (CELL_SIZE, 0), sleepTime=0.01)
 
         self.highlightCodeTags([], callEnviron)
-        self.stopAnimations()
         self.cleanUp(callEnviron)
 
     def removeFromEnd(self):
@@ -336,7 +335,6 @@ def find(self, item):
                 
                 # Animation stops
                 self.highlightCodeTags([], callEnviron)
-                self.stopAnimations()
                 self.cleanUp(callEnviron)
                 return i
 
@@ -353,7 +351,6 @@ def find(self, item):
         
         # Animation stops
         self.highlightCodeTags([], callEnviron)
-        self.stopAnimations()
         self.cleanUp(callEnviron)
         return None
 
@@ -396,7 +393,6 @@ def find(self, item):
         self.stopMergeSort()
 
         # Animation stops
-        self.stopAnimations()
         self.cleanUp(callEnviron)
 
     insertionSortCode = """
@@ -506,7 +502,6 @@ def insertionSort(self):
         self.fixCells()
 
         # Animation stops
-        self.stopAnimations()
         self.cleanUp(callEnviron)
 
     bubbleSortCode = """
@@ -569,7 +564,6 @@ def bubbleSort(self):
 
         # Animation stops
         self.highlightCodeTags([], callEnviron)
-        self.stopAnimations()
         self.cleanUp(callEnviron)
 
     selectionSortCode = """
@@ -663,7 +657,6 @@ def selectionSort(self):
 
         # Animation stops
         self.highlightCodeTags([], callEnviron)
-        self.stopAnimations()
         self.cleanUp(callEnviron)
         
     def stopMergeSort(self, toX=ARRAY_X0, toY=ARRAY_Y0):
@@ -709,8 +702,8 @@ def selectionSort(self):
             self.canvas.coords(drawItem.display_val, *self.cellCenter(i))
         self.window.update()
 
-    def cleanUp(self, *args): # Customize clean up for sorting
-        super().cleanUp(*args) # Do the VisualizationApp clean up
+    def cleanUp(self, *args, **kwargs): # Customize clean up for sorting
+        super().cleanUp(*args, **kwargs) # Do the VisualizationApp clean up
         self.fixCells()       # Restore cells to their coordinates in array
         
     def makeButtons(self):

--- a/PythonVisualizations/SimpleSorting.py
+++ b/PythonVisualizations/SimpleSorting.py
@@ -1,5 +1,4 @@
 import random
-import time
 from tkinter import *
 try:
     from drawable import *
@@ -190,11 +189,13 @@ def insert(self, item):
             [canvasDimensions[0] // 2 - CELL_SIZE, canvasDimensions[1]] * 2,
             (0, 0) + (CELL_SIZE - CELL_BORDER,) * 2)
         cellPair = self.createCellValue(startPosition, val)
+        callEnviron |= set(cellPair)
         self.moveItemsTo(cellPair, toPositions, steps=CELL_SIZE, sleepTime=0.01)
 
         # add a new Drawable with the new value, color, and display objects
         self.list.append(drawable(
             val, self.canvas.itemconfigure(cellPair[0], 'fill'), *cellPair))
+        callEnviron ^= set(cellPair) # Remove new cell from temp call environ
 
         # advance index for next insert
         self.highlightCodeTags('nitem_increment', callEnviron)

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -534,13 +534,16 @@ class VisualizationApp(object): # Base class for Python visualizations
         
     def stop(self, pauseButton):
         self.stopAnimations()
+        self.animationState = STOPPED  # Always stop animation on user request
         pauseButton['text'] = "Play"
-        pauseButton['command'] = lambda: self.onClick(self.play, pauseButton)
+        pauseButton['command'] = self.runOperation(
+            lambda: self.onClick(self.play, pauseButton), False)
 
     def pause(self, pauseButton):
         self.pauseAnimations()
         pauseButton['text'] = "Play"
-        pauseButton['command'] = lambda: self.onClick(self.play, pauseButton)
+        pauseButton['command'] = self.runOperation(
+            lambda: self.onClick(self.play, pauseButton), False)
         while self.animationState == PAUSED:
             self.wait(0.05)
 
@@ -551,14 +554,15 @@ class VisualizationApp(object): # Base class for Python visualizations
         self.animationState = RUNNING
         if self.pauseButton:
             self.pauseButton['text'] = 'Pause'
-            self.pauseButton['command'] = lambda: self.onClick(
-                self.pause, self.pauseButton)
+            self.pauseButton['command'] = self.runOperation(
+                lambda: self.onClick(self.pause, self.pauseButton), False)
             self.pauseButton['state'] = NORMAL
         if self.stopButton:
             self.stopButton['state'] = NORMAL
 
-    def stopAnimations(self):
-        # Stop the animation when called from the first level of the call stack
+    def stopAnimations(self):  # Stop animation of a call on the call stack
+        # Calls from stack level 2+ only stop animation for their level
+        # At lowest level, animation stops and play & stop buttons are disabled
         if len(self.callStack) <= 1:
             self.animationState = STOPPED
             if self.pauseButton:

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -74,6 +74,7 @@ class VisualizationApp(object):  # Base class for Python visualizations
     CODE_FONT = ('Courier', 12)
     CODE_HIGHLIGHT = 'yellow'
     CONTROLS_FONT = ('none', 14)
+    CALL_STACK_BOUNDARY = 'brown3'
 
     # Speed control slider
     SPEED_SCALE_MIN = 10
@@ -298,7 +299,7 @@ class VisualizationApp(object):  # Base class for Python visualizations
             self.codeText['xscrollcommand'] = self.codeHScroll.set
             self.codeText['yscrollcommand'] = self.codeVScroll.set
             self.codeText.tag_config('call_stack_boundary',
-                                     background=CALL_STACK_BOUNDARY)
+                                     background=self.CALL_STACK_BOUNDARY)
             
         self.codeText.configure(state=NORMAL)
         

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -341,7 +341,10 @@ class VisualizationApp(object): # Base class for Python visualizations
                 return item
             
     def cleanUp(self,         # Remove Tk items from past animations either
-                callEnviron=None): # for a particular call or all calls
+                callEnviron=None,  # for a particular call or all calls
+                stopAnimations=True): # and stop animations
+        if stopAnimations:
+            self.stopAnimations()
         minStack = 1 if callEnviron else 0 # Don't clean beyond minimum, keep
         while len(self.callStack) > minStack: # 1st call unless cleaning all
             top = self.callStack.pop()

--- a/PythonVisualizations/design/CallStackVisualization.md
+++ b/PythonVisualizations/design/CallStackVisualization.md
@@ -45,15 +45,15 @@ window.  The current block being executed would always be on top.
 
 The call to highlight a snippet would need to uniquely identify the
 callStack so that recursive calls could be handled separately.  That
-will require unique tags for each call.  The `createCodeTags()` would
-create a unique prefix for all the snippets it receives and provide a
-dictionary that translates the provided identifiers to their unique
-equivalents.  That dictionary would be stored in the callStack and
-used by `highlightCodeTags()` to find the corresponding unique tag to
-be highlighted.  The `showCode()` and `createCodeTags()` should be
-merged into a single method that creates a structure for the code
-associated with the animation method that calls it.  Let's call that
-structure a `CodeHighlightBlock` and store it in the call stack set.
+will require unique tags for each call.  The code text structure on
+top of the stack would provide a unique prefix for all the snippets it
+highlights.  When a call to an animation begins it would create the
+local environment on top of the stack along with information about the
+code and the snippets to be highlighted.  The `showCode()` and
+`createCodeTags()` should be merged into a single method that creates
+the local environment associated with the animation method that calls
+it.  Let's call the code text structure a `CodeHighlightBlock` and
+store it inside the call stack set.
 
 Presumably,
 the highlighted tags in calls below the topmost of the call stack
@@ -76,11 +76,10 @@ worrying about yet.  The background color and maybe other display
 aspects can be managed with a tag that gets added by `showCode()`.
 
 The `CodeHighlightBlock` needs to keep the line count
-of the code that was inserted for the call.  That count should include the
-boundary line so it can be cleaned up properly.  The first code block
+of the code that was inserted for the call.  The first code block
 inserted into the code window probably should not get a boundary line
 since that will be an unnecessary distraction.  Code that gets inserted
-must terminate with a newline.
+must terminate with a newline if a boundary line follows.
 
 ## API
 

--- a/PythonVisualizations/design/CallStackVisualization.md
+++ b/PythonVisualizations/design/CallStackVisualization.md
@@ -1,0 +1,84 @@
+# Visualizing the code stack and cleaning up stack frames
+
+The initial design of the code text window and the cleanup system
+assumed there was a single animation being run from a single chunk of
+source code.  The reality is that one animation/method calls other
+animations/methods to do some work, pushing them on the call stack.
+The top of the call stack is the one in active execution and animates
+most of the canvas items while highlighting code snippets being
+executed.  There might be other canvas items from lower parts of the
+stack that could either A) countinue being visible, or B) be
+temporarily hidden for restoration once control returns to that frame.
+
+Internally, VisualizationApp can manage a stack of local environments.
+The `self.cleanup` attribute would become `self.callStack` and each of its
+items would be a set of all the items that need to go away
+when the function returns/exits.  If users press Stop in the middle of
+an animation, the sysem would clean up all the callStack structures via
+a try/except handler set up by `addOperation()`.  The wait routine would throw
+an exception that is caught by the addOperation handler.
+
+The `addOperation()` method would also take care of completely cleaning up
+anything left on the callStack before invoking the operation function passed
+as an argument.  This allows the initial button to clean up everything left
+visible from a top-level operation, shifts responsibility for cleaning
+up one level of the callStack to the separate visualization modules, and
+allows for leaving some items visible ever after the animation stops (e.g.
+the outermost code).
+
+Each invocation of an animation method would:
+* push a new set on the callStack
+* put new local variable structures in the top set of the callStack
+* put a new code text structure into the top set of the callStack
+* call cleanUp on just the top of the callStack when it finishes
+
+Leaving the items on the callStack as sets that the caller can manipulate
+opens them up to being changed in unexpected ways, but leaves the
+syntax of adding items or unioning a set of items easy.  Removing items
+is just as easy.  
+
+## Showing a stack in the code window
+
+Each call to an animation method could show code and highlight it
+during "execution".  The code would go in a block of lines in the text
+window.  The current block being executed would always be on top.
+
+The call
+to highlight a snippet would need to uniquely identify the callStack
+so that recursive calls could be handled separately.  That will require
+unique tags for each call.  The `createCodeTags()` would create a
+unique prefix for all the snippets it receives and provide a dictionary
+that translates the provided identifiers to their unique equivalents.
+That dictionary would be stored in the callStack and used by `highlightCodeTags()`
+to find the corresponding unique tag to be highlighted.
+The `showCode()` and `createCodeTags()` should be merged into a single method
+that creates a structure for the code associated with the animation method
+that calls it.  Let's call that structure a `CodeHighlightBlock` and store
+it in the call stack set.
+
+Presumably,
+the highlighted tags in calls below the topmost of the call stack
+should stay highlighted while the topmost call "runs".
+That requires changing the logic that turns off highlighting everything but
+the requested tag(s) passed to `highlightCodeTags()`.  The new logic would  
+only affect highlghts for the topmost call stack set.
+
+If new code chunks are always inserted at the top of the text widget
+then the _<line>.<character>_ tag boundary indices will be correct for
+the text at the top.  Tk will then take care of keeping the tag with the
+corresponding characters in the text widget as lines are added or removed
+(only at the top of the stack).
+
+We can use some kind of boundary line of text between calls on the call stack,
+probably with a different background color.  They can span the entire width of
+of the text widget.  If the text widget shrinks in width, the boundary lines will
+wrap, but that's not an issue worth worrying about yet.  The background color
+and maybe other display aspects can be managed with a tag that gets added by
+`showCode()`.
+
+The `CodeHighlightBlock` needs to keep the line count
+of the code that was inserted for the call.  That count should include the
+boundary line so it can be cleaned up properly.  The first code block
+inserted into the code window probably should not get a boundary line
+since that will be an unnecessary distraction.  Code that gets inserted
+must terminate with a newline.


### PR DESCRIPTION
This is a significant change to the API of the VisualizationApp.  It allows for visualization to be controlled from separate calls on the call stack.  For example, the `delete()` method of Array.py calls the `find()` method to find the item to delete.  Both `delete()` and `find()` have local variables that should be shown in the visualizations, along with highlighting the code.  The two method calls can now be shown as two chunks of code in the code window and their local variables can be managed in separate environments.  (Array.py does not yet show code in this branch of the repo, and SimpleSorting.py doesn't create two levels in the call stack, but does show its code).

I've tested the branch pretty thoroughly.  It changes the way the visualization modules create their local environment, how that local environment is cleaned up, and interactions with the play/pause/stop controls.  I'd like a couple of other teams to review this PR by end-user testing it.  Future work on visualization will need to use the revised API to VisualizationApp.  Once tested, this will resolve #21, and everyone will need to migrate other modules toward this structure.