### PR TITLE
Fix code box scrolling

### DIFF
--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -336,8 +336,10 @@ class VisualizationApp(object):  # Base class for Python visualizations
                 underline=1 if highlight else 0)
             if highlight:
                 ranges = self.codeText.tag_ranges(tagName)
-                if len(ranges) > 0:
-                    self.codeText.see(ranges[0])
+                #if len(ranges) > 0:
+                    #self.codeText.see(ranges[0])
+            
+            #self.codeText.xview(MOVETO, 0)
 
     # Return the CodeHighlightBlock from the set object from the call stack
     # NOTE: this could be more efficient if the objects on the call stacks

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -301,7 +301,7 @@ class VisualizationApp(object):  # Base class for Python visualizations
             self.codeText['yscrollcommand'] = self.codeVScroll.set
             self.codeText.tag_config('call_stack_boundary',
                                      background=self.CALL_STACK_BOUNDARY)
-            
+        
         self.codeText.configure(state=NORMAL)
         
         # Add a call stack boundary line if requested and other code exists
@@ -310,11 +310,12 @@ class VisualizationApp(object):  # Base class for Python visualizations
             self.codeText.insert('1.0',
                                  self.codeText.config('width')[-1] * '-' + '\n')
             self.codeText.tag_add('call_stack_boundary', '1.0', '1.end')
-            
+        
         # Add code at top of text widget (above stack boundary, if any)
         self.codeText.insert('1.0', code + '\n')
         self.codeText.see('1.0')
-        
+        self.window.update()
+       
         # Tag the snippets with unique tag name
         for tagName in snippets:
             self.codeText.tag_add(prefix + tagName, *snippets[tagName])
@@ -336,10 +337,9 @@ class VisualizationApp(object):  # Base class for Python visualizations
                 underline=1 if highlight else 0)
             if highlight:
                 ranges = self.codeText.tag_ranges(tagName)
-                #if len(ranges) > 0:
-                    #self.codeText.see(ranges[0])
-            
-            #self.codeText.xview(MOVETO, 0)
+                if len(ranges) > 0:
+                    self.codeText.see(ranges[0])
+        
 
     # Return the CodeHighlightBlock from the set object from the call stack
     # NOTE: this could be more efficient if the objects on the call stacks


### PR DESCRIPTION
Michal and I figured out how to resolve the scroll bar issue (Issue #61) by adding the line of code that @JMCanning suggested, at the end of the highlightCodeTags method in VisualizationApp.py. 

With @lilypolonetsky's help we realized that instead we could simply remove lines 339 and 340
`if len(ranges) > 0:` and `self.codeText.see(ranges[0])` (these lines move the scroll bar towards the right in order to make the highlighted code on the screen visible, which causes the issue). Then the added line of code on line 342 `self.codeText.xview(MOVETO, 0)` is unnecessary. 

We have left these 3 lines (339, 340, 342) commented out. 