### PR TITLE
Issue162 fix initial code text resizing

### DIFF
--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -280,8 +280,8 @@ class VisualizationApp(object):  # Base class for Python visualizations
                             self.entryHintRow if self.entryHint else 1))
         if helpText:
             button.bind('<Enter>', self.makeArmHintHandler(button, helpText))
-            button.bind('<Leave>', self.makeDisarmHintHandler(button))
-            button.bind('<Button>', self.makeDisarmHintHandler(button), '+')
+            button.bind('<Leave>', self.makeDisarmHandler(button))
+            button.bind('<Button>', self.makeDisarmHandler(button), '+')
         return button
 
     def makeArgumentEntry(self, validationCmd):
@@ -295,8 +295,8 @@ class VisualizationApp(object):  # Base class for Python visualizations
             entry.bind('<KeyPress-{}>'.format(key),
                        lambda ev: self.returnPressed(ev), '+')
         entry.bind('<Enter>', self.makeArmHintHandler(entry))
-        entry.bind('<Leave>', self.makeDisarmHintHandler(entry))
-        entry.bind('<KeyRelease>', self.makeDisarmHintHandler(entry), '+')
+        entry.bind('<Leave>', self.makeDisarmHandler(entry))
+        entry.bind('<KeyRelease>', self.makeDisarmHandler(entry), '+')
         return entry
 
     def makeEntryHints(self):
@@ -326,13 +326,19 @@ class VisualizationApp(object):  # Base class for Python visualizations
                         setattr(widget, 'timeout_ID', None)))
         return handler
 
-    def makeDisarmHintHandler(self, widget):
-        def handler(event):
+    def makeDisarmHandler(self, widget):
+        def Dhandler(event):
             if event.widget == widget and getattr(widget, 'timeout_ID', None):
                 widget.after_cancel(getattr(widget, 'timeout_ID'))
             setattr(widget, 'timeout_ID', None)
-        return handler
+        return Dhandler
 
+    def makeTimer(self, widget, delay=300, attrName='timeout_ID'):
+        'Make a handler that sets a timeout that clears itself after a delay'
+        return lambda event: setattr(
+            widget, attrName,
+            widget.after(delay, lambda: setattr(widget, attrName, None)))
+    
     def returnPressed(self, event):  # Handle press of Return/Enter in text
         if hasattr(event.widget, 'last_button'): # entry argument widget
             button = getattr(event.widget, 'last_button')
@@ -468,7 +474,7 @@ class VisualizationApp(object):  # Base class for Python visualizations
         if addBoundary and currentCode and not currentCode.isspace():
             self.codeText.insert('1.0',
                                  self.codeText.config('width')[-1] * '-' + '\n')
-            self.codeText.tag_add('call_stack_boundary', '1.0', '1.end')
+            self.codetext.tag_add('call_stack_boundary', '1.0', '1.end')
         
         # Add code at top of text widget (above stack boundary, if any)
         if sleepTime > 0:
@@ -481,7 +487,10 @@ class VisualizationApp(object):  # Base class for Python visualizations
         if self.codeText:
             self.codeText.see('1.0')
         self.window.update()
-        self.resizeCodeText()
+        self.makeTimer(       # Prevent resizing codeText for a short time
+            self.codeText, delay=500)(None)
+        print('Initial codeText resize timer set')
+        self.resizeCodeText() # Set up initial codeText size
        
         # Tag the snippets with unique tag name
         if self.codeText:
@@ -490,18 +499,34 @@ class VisualizationApp(object):  # Base class for Python visualizations
             self.codeText.configure(state=DISABLED)
 
     def resizeCodeText(self, event=None):
-        if self.codeText and self.codeText.winfo_ismapped():
-            ct = self.codeText
-            nCharsWide = ct['width']
-            padX = ct['padx']
-            available = (self.window.winfo_width() -
+        if self.codeText is None or not self.codeText.winfo_ismapped():
+            return
+        ct = self.codeText
+        nCharsWide = ct['width']
+        padX = ct['padx']
+        available = (self.window.winfo_width() -
                      max(self.operationsUpper.winfo_width(),
                          self.operationsLower.winfo_width()) -
                           self.codeVScroll.winfo_width() - padX * 3)
-            desired = min(80, max(self.MIN_CODE_CHARACTER_WIDTH, 
-                                  available // self.codeTextCharWidth))
-            if desired != nCharsWide:
-                ct['width'] = desired
+        desired = min(80, max(self.MIN_CODE_CHARACTER_WIDTH, 
+                              available // self.codeTextCharWidth))
+        timeout_ID = getattr(self.codeText, 'timeout_ID', None)
+        skip = event is not None and timeout_ID is not None
+        if True:     # Set true for debugging printout
+            print('Resize codeText request based on', event,
+                  'window width =', self.window.winfo_width(),
+                  '\noperationsUpper width =',
+                  self.operationsUpper.winfo_width(), 
+                  'operationsLower width =', self.operationsLower.winfo_width(),
+                  '\nVScroll width =', self.codeVScroll.winfo_width(),
+                  'padX =', padX, 'available pixels =', available,
+                  '\ncurrent width in characters =', nCharsWide,
+                  'desired width in characters =', desired)
+            if skip:
+                print('Skipping resize whiler timer {} running'.format(
+                    timeout_ID))
+        if not skip and desired != nCharsWide:
+            ct['width'] = desired
 
     def highlightCodeTags(self, tags, callEnviron, wait=0):
         codeHighlightBlock = self.getCodeHighlightBlock(callEnviron)

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -486,12 +486,11 @@ class VisualizationApp(object):  # Base class for Python visualizations
             self.codeText.insert('1.0', code + '\n')
         if self.codeText:
             self.codeText.see('1.0')
-        self.window.update()
-        self.makeTimer(       # Prevent resizing codeText for a short time
-            self.codeText, delay=500)(None)
-        print('Initial codeText resize timer set')
+        # Doing a window update here causes multiple resize events
+        # self.window.update()
         self.resizeCodeText() # Set up initial codeText size
-       
+        self.window.update()  # Doing the update here is OK
+        
         # Tag the snippets with unique tag name
         if self.codeText:
             for tagName in snippets:
@@ -507,12 +506,12 @@ class VisualizationApp(object):  # Base class for Python visualizations
         available = (self.window.winfo_width() -
                      max(self.operationsUpper.winfo_width(),
                          self.operationsLower.winfo_width()) -
-                          self.codeVScroll.winfo_width() - padX * 3)
+                          self.codeVScroll.winfo_width() - padX * 2)
         desired = min(80, max(self.MIN_CODE_CHARACTER_WIDTH, 
                               available // self.codeTextCharWidth))
         timeout_ID = getattr(self.codeText, 'timeout_ID', None)
         skip = event is not None and timeout_ID is not None
-        if True:     # Set true for debugging printout
+        if False:     # Set true for debugging printout
             print('Resize codeText request based on', event,
                   'window width =', self.window.winfo_width(),
                   '\noperationsUpper width =',


### PR DESCRIPTION
This fixes the multiple resizings of the codeText box when it is first exposed.  I tested it under macOS and Windows and found it worked properly.  I used a modification to the SimpleSearch.py program called SimpleSortingResize.py in this 
[SimpleSortingResize.zip](https://github.com/JMCanning78/datastructures-visualization/files/5585796/SimpleSortingResize.zip) file for testing.  When you launch the program, it has a long hint message showing.  That expands the size of the window.  If you run the Selection Sort before dismissing that hint, the multiple resizing problem occurs (in the previous version of VisualizationApp.py).  After the fix in commit 0f09e54, it might resize twice, but not multiple times in short succession causing flashing.  The key changes were moving the window.update() call after the first call to resizeCodeText() and changing the formula for calculating how wide the codeText window should be in characters.

I left some extra code in VisualizationApp for applying a timeout period on the codeText box which would prevent resize requests from changing the codeText width.  These might be useful if we discover a new condition that causes multiple resizing to occur.  

