### PR TITLE
Issue172 base prioirty queue on sorting base

### DIFF
--- a/PythonVisualizations/PriorityQueue.py
+++ b/PythonVisualizations/PriorityQueue.py
@@ -2,105 +2,64 @@ import random
 from tkinter import *
 
 try:
-    from drawable import *
+    from drawnValue import *
     from SortingBase import *
 except ModuleNotFoundError:
-    from .drawable import *
+    from .drawnValue import *
     from .SortingBase import *
 
 
 class PriorityQueue(SortingBase):
-    CELL_SIZE = 50
-    CELL_BORDER = 2
-    CELL_BORDER_COLOR = 'black'
-    ARRAY_X0 = 100
-    ARRAY_Y0 = 100
 
     nextColor = 0
 
     def __init__(self, size=12, title="Priority Queue", **kwargs):
-        super().__init__(title=title, **kwargs)
-        self.size = size
-        self.title = title
-        self.list = [None]*self.size
-        self.nItems = 0
-        self.index = None
+        super().__init__(size=size, title=title, **kwargs)
+
+        self.nItems = None
         self.buttons = self.makeButtons()
         
         self.display()
 
-    def __str__(self):
-        return str(self.list)
-
     # ARRAY FUNCTIONALITY
-
-    def createIndex(self, index,  # cell
-                    name=None,  # with an optional name label
-                    level=1,  # at a particular level away from the cells
-                    color=None):  # (negative are below)
-        if not color: color = self.VARIABLE_COLOR
-
-        cell_coords = self.cellCoords(index)
-        cell_center = self.cellCenter(index)
-        level_spacing = abs(self.VARIABLE_FONT[1])
-        x = cell_center[0]
-        if level > 0:
-            y0 = cell_coords[1] - self.CELL_SIZE * 3 // 5 - level * level_spacing
-            y1 = cell_coords[1] - self.CELL_SIZE * 3 // 10
-        else:
-            y0 = cell_coords[3] + self.CELL_SIZE * 3 // 5 - level * level_spacing
-            y1 = cell_coords[3] + self.CELL_SIZE * 3 // 10
-        arrow = self.canvas.create_line(
-            x, y0, x, y1, arrow="last", fill=color)
-        if name:
-            label = self.canvas.create_text(
-                x + 2, y0, text=name, anchor=SW if level > 0 else NW,
-                font=self.VARIABLE_FONT, fill=color)
-        return (arrow, label) if name else (arrow,)
 
     def insert(self, val):
         callEnviron = self.createCallEnvironment()
         self.startAnimations()
-        j = self.nItems - 1  # Start at front
+        j = len(self.list) - 1  # Start at front
 
         indexJ = self.createIndex(j, 'j', level=-2)
         callEnviron |= set(indexJ)
 
-        #self.list[j] = drawable(None)
-        self.list[self.nItems] = drawable(None)
-        
-        self.wait(1)
+        self.wait(0.2)
             
+        self.list.append(drawnValue(None, None, None))
         while j >= 0 and val >= self.list[j].val:  # Move bigger items right
 
             self.assignElement(j, j+1, callEnviron)
             self.list[j+1].val = self.list[j].val
             j -= 1
-            self.moveItemsBy(indexJ, (-self.CELL_SIZE, 0), sleepTime=0.1)  # Move "j" arrow
-            self.wait(1)
+            self.moveItemsBy(indexJ, (-self.CELL_SIZE, 0), sleepTime=0.02)  # Move "j" arrow
             
         # Location of the new cell in the array
-        toPositions = (self.cellCoords(j+1),
+        toPositions = (self.fillCoords(val, self.cellCoords(j+1)),
                        self.cellCenter(j+1))
 
         # Animate arrival of new value from operations panel area
         canvasDimensions = self.widgetDimensions(self.canvas)
-        startPosition = [canvasDimensions[0] // 2, canvasDimensions[1]] * 2
-        startPosition = add_vector(startPosition, (0, 0, self.CELL_SIZE, self.CELL_SIZE))
+        coords = self.cellCoords(0)
+        delta = subtract_vector((canvasDimensions[0] // 2, canvasDimensions[1]),
+                                coords[:2])
+        startPosition = add_vector(coords, delta * 2)
         cellPair = self.createCellValue(startPosition, val)
         callEnviron |= set(cellPair)  # Mark new cell as temporary
-        self.moveItemsTo(cellPair, toPositions, steps=self.CELL_SIZE, sleepTime=0.01)
-        self.list[j+1] = drawable(
-            val, self.canvas.itemconfigure(cellPair[0], 'fill')[-1], *cellPair)
+        self.moveItemsTo(cellPair, toPositions, sleepTime=0.01)
+        self.list[j+1] = drawnValue(val, *cellPair)
         callEnviron -= set(cellPair)  # New cell is no longer temporary
 
-        self.nItems += 1
-        self.moveItemsBy(self.index, (self.CELL_SIZE, 0), sleepTime=0.01)
+        self.moveItemsBy(self.nItems, (self.CELL_SIZE, 0), sleepTime=0.01)
 
-        self.window.update()  
         self.cleanUp(callEnviron) 
-        self.stopAnimations()
-
 
     def peek(self):
         callEnviron = self.createCallEnvironment()
@@ -111,9 +70,9 @@ class PriorityQueue(SortingBase):
         spacing = self.CELL_SIZE * 3 // 4
         padding = 10
         outputBox = self.canvas.create_rectangle(
-            (canvasDimensions[0] - self.nItems * spacing - padding) // 2,
+            (canvasDimensions[0] - len(self.list) * spacing - padding) // 2,
             canvasDimensions[1] - self.CELL_SIZE - padding,
-            (canvasDimensions[0] + self.nItems * spacing + padding) // 2,
+            (canvasDimensions[0] + len(self.list) * spacing + padding) // 2,
             canvasDimensions[1] - padding,
             fill=self.OPERATIONS_BG)
         callEnviron.add(outputBox)
@@ -125,7 +84,7 @@ class PriorityQueue(SortingBase):
         midOutputBox = (outputBoxCoords[3] + outputBoxCoords[1]) // 2
 
         # create the value to move to output box
-        valueOutput = self.copyCanvasItem(self.list[self.nItems-1].display_val)
+        valueOutput = self.copyCanvasItem(self.list[-1].items[1])
         valueList = (valueOutput,)
         callEnviron.add(valueOutput)
 
@@ -140,150 +99,47 @@ class PriorityQueue(SortingBase):
 
         self.wait(0.3)
         self.cleanUp(callEnviron)
-
-    def assignElement(
-            self, fromIndex, toIndex, callEnviron,
-            steps=CELL_SIZE // 2, sleepTime=0.01):
-        fromDrawable = self.list[fromIndex]
-
-        # get positions of "to" cell in array
-        toPositions = (self.cellCoords(toIndex), self.cellCenter(toIndex))
-
-        # create new display objects as copies of the "from" cell and value
-        newCell = self.copyCanvasItem(fromDrawable.display_shape)
-        newCellVal = self.copyCanvasItem(fromDrawable.display_val)
-        callEnviron |= set([newCell, newCellVal])
-
-        # Move copies to the desired location
-        self.moveItemsTo((newCell, newCellVal), toPositions, steps=steps,
-                         sleepTime=sleepTime)
-
-        # delete the original "to" display value and the new display shape
-        self.canvas.delete(self.list[toIndex].display_val)
-        self.canvas.delete(self.list[toIndex].display_shape)
-
-        # update value and display value in "to" position in the list
-        self.list[toIndex].display_val = newCellVal
-        self.list[toIndex].val = self.list[fromIndex].val
-        self.list[toIndex].display_shape = newCell
-        self.list[toIndex].color = self.list[fromIndex].color
-        callEnviron ^= set([newCell, newCellVal])
-
-        # update the window
-        self.window.update()
-
-    def cellCoords(self, cell_index):  # Get bounding rectangle for array cell
-        return (self.ARRAY_X0 + self.CELL_SIZE * cell_index, self.ARRAY_Y0,  # at index
-                self.ARRAY_X0 + self.CELL_SIZE * (cell_index + 1) - self.CELL_BORDER,
-                self.ARRAY_Y0 + self.CELL_SIZE - self.CELL_BORDER)
-
-    def cellCenter(self, index):  # Center point for array cell at index
-        half_cell = (self.CELL_SIZE - self.CELL_BORDER) // 2
-        return add_vector(self.cellCoords(index), (half_cell, half_cell))
-
-    def createArrayCell(self, index):  # Create a box representing an array cell
-        cell_coords = self.cellCoords(index)
-        half_border = self.CELL_BORDER // 2
-        rect = self.canvas.create_rectangle(
-            *add_vector(cell_coords,
-                        (-half_border, -half_border,
-                         self.CELL_BORDER - half_border, self.CELL_BORDER - half_border)),
-            fill=None, outline=self.CELL_BORDER_COLOR, width=self.CELL_BORDER)
-        self.canvas.lower(rect)
-        return rect
-
-    def createCellValue(self, indexOrCoords, key, color=None):
-        """Create new canvas items to represent a cell value.  A square
-        is created filled with a particular color with an text key centered
-        inside.  The position of the cell can either be an integer index in
-        the Array or the bounding box coordinates of the square.  If color
-        is not supplied, the next color in the palette is used.
-        An event handler is set up to update the VisualizationApp argument
-        with the cell's value if clicked with any button.
-        Returns the tuple, (square, text), of canvas items
-        """
-        # Determine position and color of cell
-        if isinstance(indexOrCoords, int):
-            rectPos = self.cellCoords(indexOrCoords)
-            valPos = self.cellCenter(indexOrCoords)
-        else:
-            rectPos = indexOrCoords
-            valPos = divide_vector(add_vector(rectPos[:2], rectPos[2:]), 2)
-        if color is None:
-            # Take the next color from the palette
-            color = drawable.palette[self.nextColor]
-            self.nextColor = (self.nextColor + 1) % len(drawable.palette)
-
-        cell_rect = self.canvas.create_rectangle(
-            *rectPos, fill=color, outline='', width=0)
-        cell_val = self.canvas.create_text(
-            *valPos, text=str(key), font=self.VALUE_FONT, fill=self.VALUE_COLOR)
-        handler = lambda e: self.setArgument(str(key))
-        for item in (cell_rect, cell_val):
-            self.canvas.tag_bind(item, '<Button>', handler)
-
-        return cell_rect, cell_val
-
-    def display(self):
-        self.canvas.delete("all")
-
-        self.index = self.createIndex(self.nItems, 'nItems', level=-1) # indicate priority        
-
-        for i in range(self.size):  # Draw grid of cells
-            self.createArrayCell(i)
-
-        # go through each Drawable in the list
-        for i in range(self.nItems):
-            drawItem = self.list[i]
-            if drawItem:
-                self.canvas.coords(drawItem.display_shape, *self.cellCoords(i))
-                self.canvas.coords(drawItem.display_val, *self.cellCenter(i))            
-
-        self.window.update()
         
     def newArraySize(self, val):
         callEnviron = self.createCallEnvironment()                
         # Clear Array and reset size and list
         self.size = val
-        self.list = [None]*self.size
-        self.nItems = 0
+        self.list = []
         
         self.display()
         self.cleanUp(callEnviron)
 
     # delete the last element of the queue, or None if empty
     def remove(self):
-        callEnviron = self.createCallEnvironment()
-        if self.nItems == 0:
+        if len(self.list) == 0:
             self.setMessage('Array is empty!')
             return
+        callEnviron = self.createCallEnvironment()
         self.startAnimations()
         self.wait(0.3)
 
-        n = self.list[self.nItems - 1]
+        n = self.list.pop()
+        callEnviron |= set(n.items)
 
         # Slide value rectangle up and off screen
-        items = (n.display_shape, n.display_val)
-        self.moveItemsOffCanvas(items, N, sleepTime=0.02)
+        self.moveItemsOffCanvas(n.items, N, sleepTime=0.02)
 
-        self.nItems -= 1
-        self.moveItemsBy(self.index, (-self.CELL_SIZE, 0))  # move priority arrow
-
-        n = self.list.pop()
+        self.moveItemsBy(self.nItems, (-self.CELL_SIZE, 0), sleepTime=0.02)
 
         self.cleanUp(callEnviron)
 
     def fixPositions(self):     # Move canvas display items to exact coords
-        for i in range(self.nItems):
-            drawItem = self.list[i]
+        for i, drawItem in enumerate(self.list):
             if drawItem:    # if i contains a cell...move the cells
-                self.canvas.coords(drawItem.display_shape, *self.cellCoords(i))
-                self.canvas.coords(drawItem.display_val, *self.cellCenter(i))
+                self.canvas.coords(drawItem.items[0], 
+                                   *self.fillCoords(drawItem.val, 
+                                                    self.cellCoords(i)))
+                self.canvas.coords(drawItem.items[1], *self.cellCenter(i))
 
         # Move nItems index to position in array
-        x = self.cellCenter(self.nItems)[0]
+        x = self.cellCenter(len(self.list))[0]
         # Use y coord from nItems index but x value from target location
-        for item in self.index:
+        for item in self.nItems:
             coords = [x if i%2 == 0 else c
                       for i, c in enumerate(self.canvas.coords(item))]
             self.canvas.coords(item, *coords)
@@ -322,7 +178,7 @@ class PriorityQueue(SortingBase):
         if val is None:
             self.setMessage("Input value must be an integer from 0 to 99.")
         else:
-            if self.nItems >= self.size:
+            if len(self.list) >= self.size:
                 self.setMessage("Error! Queue is already full.")
             else:
                 self.insert(val)
@@ -334,10 +190,10 @@ class PriorityQueue(SortingBase):
         self.clearArgument()
 
     def clickPeek(self):
-        if self.nItems <= 0: self.setMessage("Error! Queue is empty.")
+        if len(self.list) <= 0: self.setMessage("Error! Queue is empty.")
         else:
             self.peek()
-            self.setMessage("Value at front is {}".format(self.list[self.nItems-1].val))
+            self.setMessage("Value at front is {}".format(self.list[-1].val))
 
     def clickNew(self):
         val = self.validArgument()

--- a/PythonVisualizations/PriorityQueue.py
+++ b/PythonVisualizations/PriorityQueue.py
@@ -29,14 +29,25 @@ def isFull(self):
 '''
 
     def isFull(self, code=isFullCode, wait=0.2):
-        callEnviron = self.createCallEnvironment(
-            code=code.format(**locals()))
+        callEnviron = self.createCallEnvironment(code=code)
         self.startAnimations()
-    
         self.highlightCode(
             'self.__nItems == self.__maxSize', callEnviron, wait=wait)
         self.cleanUp(callEnviron)
         return len(self.list) == self.size
+
+    isEmptyCode = '''
+def isEmpty(self):
+   return self.__nItems == 0
+'''
+
+    def isEmpty(self, code=isEmptyCode, wait=0.2):
+        callEnviron = self.createCallEnvironment(code=code)
+        self.startAnimations()
+        self.highlightCode(
+            'self.__nItems == 0', callEnviron, wait=wait)
+        self.cleanUp(callEnviron)
+        return len(self.list) == 0
 
     insertCode = '''
 def insert(self, item={val}):
@@ -58,7 +69,7 @@ def insert(self, item={val}):
         self.startAnimations()
 
         wait=0.2
-        self.highlightCode('self.isFull()', callEnviron)
+        self.highlightCode('self.isFull()', callEnviron, wait=0.01)
         if self.isFull():
             self.highlightCode(
                 'raise Exception("Queue overflow")', callEnviron, 
@@ -71,6 +82,14 @@ def insert(self, item={val}):
 
         indexJ = self.createIndex(j, 'j', level=-2)
         callEnviron |= set(indexJ)
+
+        startPosition = self.tempCoords(j + 1)
+        cell = self.createCellValue(startPosition, val)
+        itemLabel = self.canvas.create_text(
+            *self.tempLabelCoords(j + 1, self.VARIABLE_FONT), text='item', 
+            font=self.VARIABLE_FONT, fill=self.VARIABLE_COLOR)
+        newItem = cell + (itemLabel,)
+        callEnviron |= set(newItem)
 
         self.highlightCode('j >= 0', callEnviron, wait=wait)
         if j >= 0:
@@ -85,7 +104,8 @@ def insert(self, item={val}):
 
             self.highlightCode('j -= 1', callEnviron)
             j -= 1
-            self.moveItemsBy(indexJ, (-self.CELL_SIZE, 0), sleepTime=0.02)
+            self.moveItemsBy(indexJ + newItem, (-self.CELL_SIZE, 0),
+                             sleepTime=0.02)
 
             self.highlightCode('j >= 0', callEnviron, wait=wait)
             if j >= 0:
@@ -98,17 +118,9 @@ def insert(self, item={val}):
         toPositions = (self.fillCoords(val, self.cellCoords(j+1)),
                        self.cellCenter(j+1))
 
-        # Animate arrival of new value from operations panel area
-        canvasDimensions = self.widgetDimensions(self.canvas)
-        coords = self.cellCoords(0)
-        delta = subtract_vector((canvasDimensions[0] // 2, canvasDimensions[1]),
-                                coords[:2])
-        startPosition = add_vector(coords, delta * 2)
-        cellPair = self.createCellValue(startPosition, val)
-        callEnviron |= set(cellPair)  # Mark new cell as temporary
-        self.moveItemsTo(cellPair, toPositions, sleepTime=0.01)
-        self.list[j+1] = drawnValue(val, *cellPair)
-        callEnviron -= set(cellPair)  # New cell is no longer temporary
+        self.moveItemsTo(cell, toPositions, sleepTime=0.01)
+        self.list[j+1] = drawnValue(val, *cell)
+        callEnviron -= set(cell)  # New cell is no longer temporary
 
         self.highlightCode('self.__nItems += 1', callEnviron)
         self.moveItemsBy(self.nItems, (self.CELL_SIZE, 0), sleepTime=0.01)
@@ -117,72 +129,144 @@ def insert(self, item={val}):
         self.cleanUp(callEnviron)
         return True
 
-    def peek(self):
-        callEnviron = self.createCallEnvironment()
+    peekCode = '''
+def peek(self):
+   return None if self.isEmpty() else self.__que[self.__front]
+'''
+    
+    def peek(self, code=peekCode):
+        callEnviron = self.createCallEnvironment(code=code)
         self.startAnimations()
 
-        # draw output box
-        canvasDimensions = self.widgetDimensions(self.canvas)
-        spacing = self.CELL_SIZE * 3 // 4
-        padding = 10
+        self.highlightCode('self.isEmpty()', callEnviron, wait=0.01)
+        if self.isEmpty():
+            self.highlightCode('None', callEnviron)
+            self.cleanUp(callEnviron)
+            return None
+            
+        self.highlightCode('self.__que[self.__front]', callEnviron)
+        # draw output box using smaller font than values
+        font = (self.VALUE_FONT[0], - abs(self.VALUE_FONT[1]) * 3 // 4)
+        outputBoxCoords = self.outputBoxCoords(font, n=1)
         outputBox = self.canvas.create_rectangle(
-            (canvasDimensions[0] - len(self.list) * spacing - padding) // 2,
-            canvasDimensions[1] - self.CELL_SIZE - padding,
-            (canvasDimensions[0] + len(self.list) * spacing + padding) // 2,
-            canvasDimensions[1] - padding,
-            fill=self.OPERATIONS_BG)
+            *outputBoxCoords, fill=self.OPERATIONS_BG)
         callEnviron.add(outputBox)
 
-        self.wait(0.3)
+        self.wait(0.1)
 
         # calculate where the value will need to move to
-        outputBoxCoords = self.canvas.coords(outputBox)
-        midOutputBox = (outputBoxCoords[3] + outputBoxCoords[1]) // 2
+        midOutputBox = divide_vector(
+            add_vector(outputBoxCoords[:2], outputBoxCoords[2:]), 2)
 
         # create the value to move to output box
         valueOutput = self.copyCanvasItem(self.list[-1].items[1])
-        valueList = (valueOutput,)
         callEnviron.add(valueOutput)
 
         # move value to output box
-        toPositions = (outputBoxCoords[0] + padding / 2 + (1 / 2) * spacing,
-                       midOutputBox)
-        self.moveItemsTo(valueList, (toPositions,), sleepTime=.02)
+        self.moveItemsTo(valueOutput, midOutputBox, sleepTime=.02)
 
-        # make the value 25% smaller
-        newSize = (self.VALUE_FONT[0], int(self.VALUE_FONT[1] * .75))
-        self.canvas.itemconfig(valueOutput, font=newSize)
+        # adjust the font of the output item
+        self.canvas.itemconfig(valueOutput, font=font)
 
-        self.wait(0.3)
+        self.wait(0.1)
         self.cleanUp(callEnviron)
+        return self.list[-1].val
+
+    newCode = '''
+def __init__(self, size={val}, pri=identity):
+   self.__maxSize = size
+   self.__que = [None] * size
+   self.__pri = pri
+   self.__nItems = 0
+'''
+    
+    def newArraySize(self, val, code=newCode):
+        callEnviron = self.createCallEnvironment(code=code.format(**locals()))
+        self.startAnimations()
+
+        cell0 = self.cellCoords(0)
+        pad = abs(self.VARIABLE_FONT[1])
+        self.canvas.delete('all')
+        wait=0.1
+        callEnviron.add(self.canvas.create_text(
+            *cell0[:2], text='__maxSize = {}'.format(val), anchor=SW,
+            font=self.VARIABLE_FONT, fill=self.VARIABLE_COLOR))
+        try:
+            self.highlightCode('self.__maxSize = size', callEnviron, wait=wait)
+        except UserStop:
+            wait = 0
         
-    def newArraySize(self, val):
-        callEnviron = self.createCallEnvironment()                
-        # Clear Array and reset size and list
+        self.highlightCode('self.__que = [None] * size', callEnviron)
         self.size = val
         self.list = []
-        
+        self.display(showNItems=False)
+        callEnviron.add(self.canvas.create_text(
+            pad, (cell0[1] + cell0[3]) // 2,
+            text='__que', anchor=W, font=self.VARIABLE_FONT,
+            fill=self.VARIABLE_COLOR))
+        try:
+            self.wait(wait)
+        except UserStop:
+            wait = 0
+            
+        self.highlightCode('self.__pri = pri', callEnviron)
+        callEnviron.add(self.canvas.create_text(
+            cell0[0],  (cell0[1] + 2 * cell0[3]) // 2,
+            text='__pri = identity', font=self.VARIABLE_FONT,
+            fill=self.VARIABLE_COLOR))
+        try:
+            self.wait(wait)
+        except UserStop:
+            wait = 0
+
+        self.highlightCode('self.__nItems = 0', callEnviron)
         self.display()
+        try:
+            self.wait(wait)
+        except UserStop:
+            wait = 0
+
         self.cleanUp(callEnviron)
 
+    removeCode = '''
+def remove(self):
+   if self.isEmpty():
+      raise Exception("Queue underflow")
+   self.__nItems -= 1
+   front = self.__que[self.__nItems]
+   self.__que[self.__nItems] = None
+   return front
+'''
+    
     # delete the last element of the queue, or None if empty
-    def remove(self):
-        if len(self.list) == 0:
-            self.setMessage('Array is empty!')
-            return
-        callEnviron = self.createCallEnvironment()
+    def remove(self, code=removeCode):
+        callEnviron = self.createCallEnvironment(code=code)
         self.startAnimations()
+
+        self.highlightCode('self.isEmpty()', callEnviron, wait=0.01)
+        if self.isEmpty():
+            self.highlightCode('raise Exception("Queue underflow")',
+                               callEnviron, color=self.EXCEPTION_HIGHLIGHT)
+            self.cleanUp(callEnviron)
+            return
         self.wait(0.3)
 
-        n = self.list.pop()
-        callEnviron |= set(n.items)
-
-        # Slide value rectangle up and off screen
-        self.moveItemsOffCanvas(n.items, N, sleepTime=0.02)
-
+        self.highlightCode('self.__nItems -= 1', callEnviron)
         self.moveItemsBy(self.nItems, (-self.CELL_SIZE, 0), sleepTime=0.02)
 
+        self.highlightCode('front = self.__que[self.__nItems]', callEnviron)
+        self.assignToTemp(len(self.list) - 1, callEnviron, varName='front')
+        n = self.list.pop()
+
+        self.highlightCode('self.__que[self.__nItems] = None', callEnviron,
+                           wait=0.1)
+        for item in n.items:
+            if item is not None:
+                self.canvas.delete(item)
+
+        self.highlightCode('return front', callEnviron, wait=0.1)
         self.cleanUp(callEnviron)
+        return n.val
 
     def fixPositions(self):     # Move canvas display items to exact coords
         for i, drawItem in enumerate(self.list):
@@ -208,19 +292,25 @@ def insert(self, item={val}):
             kwargs.get('callEnviron', None) is None): # call stack,
             self.fixPositions()   # Restore cells to their coordinates in array
 
-    def makeButtons(self):
+    def makeButtons(self, maxRows=4):
         vcmd = (self.window.register(numericValidate),
                 '%d', '%i', '%P', '%s', '%S', '%v', '%V', '%W')
-        newSizeArrayButton = self.addOperation(
-            "New", lambda: self.clickNew(), numArguments=1, validationCmd=vcmd)
         insertButton = self.addOperation(
-            "Insert", lambda: self.clickInsert(), numArguments=1, validationCmd=vcmd)
-        deleteButton = self.addOperation(
-            "Remove", lambda: self.clickRemove(), numArguments=0)
+            "Insert", lambda: self.clickInsert(), numArguments=1, 
+            argHelpText=['item'], helpText='Insert item by its priority',
+            validationCmd=vcmd)
+        newSizeArrayButton = self.addOperation(
+            "New", lambda: self.clickNew(), numArguments=1,
+            argHelpText=['number of items'], validationCmd=vcmd, 
+            helpText='Create new priority queue for N items')
+        removeButton = self.addOperation(
+            "Remove", lambda: self.clickRemove(),
+            helpText='Remove highest priority (lowest numbered) item')
         peekButton = self.addOperation(
-            "Peek", lambda: self.clickPeek(), numArguments=0)
+            "Peek", lambda: self.clickPeek(),
+            helpText='Peek at highest priority (lowest numbered) item')
         self.addAnimationButtons()
-        return [insertButton, deleteButton, peekButton]
+        return [insertButton, newSizeArrayButton, removeButton, peekButton]
 
     def validArgument(self):
         entered_text = self.getArgument()
@@ -233,34 +323,39 @@ def insert(self, item={val}):
         val = self.validArgument()
         self.setMessage(
             "Input value must be an integer from 0 to 99." if val is None else
-            "Value {} inserted".format(val) if self.insert(val) else
+            "Item {} inserted".format(val) if self.insert(val) else
             "Error! Queue is already full.")
                 
         self.clearArgument()
     
     def clickRemove(self):
         result = self.remove()
+        self.setMessage(
+            "Error! Queue is empty." if result is None else
+            "Item {} removed".format(result))
         self.clearArgument()
 
     def clickPeek(self):
-        if len(self.list) <= 0: self.setMessage("Error! Queue is empty.")
-        else:
-            self.peek()
-            self.setMessage("Value at front is {}".format(self.list[-1].val))
+        front = self.peek()
+        self.setMessage("Error! Queue is empty." if front is None else
+                        "Item at front is {}".format(front))
 
     def clickNew(self):
         val = self.validArgument()
-        # If the number of cells desired wouldn't fit on the screen, error message
-        if val is None or self.window.winfo_width() <= self.ARRAY_X0 + (val+1) * self.CELL_SIZE:
-            self.setMessage("This array size is too big to display")
-        elif val == 0:
-            self.setMessage("This array size is too small")
-        else:
-            self.newArraySize(val)
+        canvasDims = self.widgetDimensions(self.canvas)
+        maxCells = (canvasDims[0] - self.ARRAY_X0) // self.CELL_SIZE - 1
+        # Error if number of desired cells won't fit on canvas
+        if val is None or 0 == val or val > maxCells:
+            self.setMessage("This queue size must be beteeen 1 and {}".format(
+                maxCells))
+            return
+        self.newArraySize(val)
         self.clearArgument()
-
-
 
 if __name__ == '__main__':
     queue = PriorityQueue()
+    keys = [int(arg) for arg in sys.argv[1:queue.size + 1] if arg.isdigit()]
+    keys.sort(reverse=True)
+    queue.list = [drawnValue(key, None, None) for key in keys]
+    queue.display()
     queue.runVisualization()

--- a/PythonVisualizations/PriorityQueue.py
+++ b/PythonVisualizations/PriorityQueue.py
@@ -3,13 +3,13 @@ from tkinter import *
 
 try:
     from drawable import *
-    from VisualizationApp import *
+    from SortingBase import *
 except ModuleNotFoundError:
     from .drawable import *
-    from .VisualizationApp import *
+    from .SortingBase import *
 
 
-class PriorityQueue(VisualizationApp):
+class PriorityQueue(SortingBase):
     CELL_SIZE = 50
     CELL_BORDER = 2
     CELL_BORDER_COLOR = 'black'

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -685,8 +685,8 @@ def traverse(self, function=print):
         for i, n in enumerate(self.list):
             # create display objects for the associated Drawables
             n.display_shape, n.display_val = self.createCellValue(
-                i, n.val, n.color)
-            n.color = self.canvas.itemconfigure(n.display_shape, 'fill')[-1]
+                i, n.val)   # , n.color)
+            # n.color = self.canvas.itemconfigure(n.display_shape, 'fill')[-1]
 
         # draw an index pointing to the last item in the list
         if showNItems:

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -80,7 +80,7 @@ class SortingBase(VisualizationApp):
     
     def assignToTemp(self, index, callEnviron, varName="temp", existing=None):
         """Assign indexed cell to a temporary variable named varName.
-        Animate value moving to the temporary variable above the array.
+        Animate value moving to the temporary variable below the array.
         Return a drawable for the new temporary value and a text item for
         its name.  The existing name item can be passed to avoid creating
         a new one and for moving the value to that location
@@ -99,17 +99,18 @@ class SortingBase(VisualizationApp):
         tempPos = self.tempCoords(index)
         if existing:
             tempLabelPos = self.canvas.coords(existing)
-            templabel = existing
+            tempLabel = existing
         else:
             tempLabelPos = self.tempLabelCoords(index, self.VARIABLE_FONT)
-            templabel = self.canvas.create_text(
+            tempLabel = self.canvas.create_text(
                 *tempLabelPos, text=varName, font=self.VARIABLE_FONT,
                 fill=self.VARIABLE_COLOR)
+            callEnviron.add(tempLabel)
 
         delta = (tempLabelPos[0] - cellXCenter, tempPos[1] - posCell[1])
         self.moveItemsBy(items, delta, sleepTime=0.02)
 
-        return drawable(fromDraw.val, fromDraw.color, *items), templabel
+        return drawable(fromDraw.val, fromDraw.color, *items), tempLabel
 
     def assignFromTemp(self, index, temp, templabel):
 

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -60,7 +60,7 @@ class SortingBase(VisualizationApp):
 
         # update value and display value in "to" position in the list
         toItem.val = fromItem.val
-        toItem.color = fromItem.color
+        # toItem.color = fromItem.color
         toItem.display_shape = items[0]
         toItem.display_val = items[1] if len(items) > 1 else None
         


### PR DESCRIPTION
This PR should close #172 by basing the `PriorityQueue` class on the `SortingBase` class.  It also:

- converts to the use of `drawnValue` in place of `drawable` records
- makes the operation button order consistent with the other array visualization apps
- shows and highlights the code of all the operations
- adds hint text for all the buttons and one argument

It fixes a bug in `SortingBase` where the `tempLabel` made in `assignToTemp()` is not put in the callEviron.