### PR TITLE
Change logic for finding subclasses of VisualizationApp

### DIFF
--- a/PythonVisualizations/runAllVisualizations.py
+++ b/PythonVisualizations/runAllVisualizations.py
@@ -15,9 +15,10 @@ from tkinter import *
 from tkinter import ttk
 
 try:
-    from VisualizationApp import *
+    import VisualizationApp
+    VAP = VisualizationApp.VisualizationApp
 except ModuleNotFoundError:
-    from .VisualizationApp import *
+    from .VisualizationApp import VisualizationApp as VAP
 
 PREFERRED_ARRANGEMENT = [
     ['Chapters 1-4',
@@ -45,6 +46,14 @@ def findVisualizations(filesAndDirectories, verbose=0):
                   file=sys.stderr)
         files = glob.glob(os.path.join(fileOrDir, '*.py')) if isDir else [
                    fileOrDir]
+        if verbose > 1:
+            print(
+                'Looking for "runVisualization()" in',
+                '{} python files in {}'.format(len(files), fileOrDir) if isDir
+                else fileOrDir,
+                file=sys.stderr)
+            if verbose > 2 and isDir:
+                print('Files:', '\n'.join(files), file=sys.stderr)
         for filename in [f for f in files 
                          if isStringInFile('runVisualization()', f)]:
             dirs = pathsep.split(os.path.normpath(os.path.dirname(filename)))
@@ -54,13 +63,24 @@ def findVisualizations(filesAndDirectories, verbose=0):
             if modulename:
                 try:
                     fullmodulename = '.'.join(dirs + [modulename])
+                    if verbose > 1:
+                        print('Attempting to import {} ... ' .format(
+                            fullmodulename), file=sys.stderr, end='')
                     module = import_module(fullmodulename)
                     if verbose > 1:
-                        print('Imported {} and looking for VisualizationApp'
+                        print('Imported. Looking for VisualizationApp'
                               .format(fullmodulename),
                               file=sys.stderr)
-                    classes |= set(findVisualizationClasses(
-                        module, verbose=verbose))
+                    newclasses = findVisualizationClasses(module, verbose)
+                    if verbose > 1:
+                        print('Found {} matching classes: {}'
+                              .format(len(newclasses), newclasses),
+                              file=sys.stderr)
+                        previouslyFound = set(newclasses) & classes
+                        if len(previouslyFound) > 0:
+                            print('Previously found:', previouslyFound,
+                                  file=sys.stderr)
+                    classes |= set(newclasses)
                 except ModuleNotFoundError:
                     if verbose > 0:
                         print('Unable to import module', modulename,
@@ -74,14 +94,10 @@ def isStringInFile(text, filename):
 def findVisualizationClasses(module, verbose=0):
     classes = []
     for name in dir(module):
-        this = getattr(module, name)
-        if isinstance(this, type(VisualizationApp)) and (
-                hasattr(this, 'runVisualization') and
-                len(this.__subclasses__()) == 0 and
-                this is not VisualizationApp):
-            if verbose > 1:
-                print('Found {}.{}, a subclass of VisualizationApp'.format(
-                    module.__name__, name))
+        this = getattr(module, name)          # Check if this 
+        if (isinstance(this, type(object)) and # is a class
+            issubclass(this, VAP) and this is not VAP and # a subclass of VAP
+            this.__module__ == module.__name__): # defined in ths module
             classes.append(this)
         elif verbose > 2:
             print('Ignoring {}.{} of type {}'.format(

--- a/PythonVisualizations/runAllVisualizations.py
+++ b/PythonVisualizations/runAllVisualizations.py
@@ -40,10 +40,6 @@ def findVisualizations(filesAndDirectories, verbose=0):
     classes = set()
     for fileOrDir in filesAndDirectories:
         isDir = os.path.isdir(fileOrDir)
-        if verbose > 1:
-            print('Looking for "runVisualization()" in',
-                  'python files in {}'.format(fileOrDir) if isDir else isDir,
-                  file=sys.stderr)
         files = glob.glob(os.path.join(fileOrDir, '*.py')) if isDir else [
                    fileOrDir]
         if verbose > 1:

--- a/PythonVisualizations/runAllVisualizationsMenu.py
+++ b/PythonVisualizations/runAllVisualizationsMenu.py
@@ -18,9 +18,10 @@ from tkinter import *
 from tkinter import ttk
 
 try:
-    from VisualizationApp import *
+    import VisualizationApp
+    VAP = VisualizationApp.VisualizationApp
 except ModuleNotFoundError:
-    from .VisualizationApp import *
+    from .VisualizationApp import VisualizationApp as VAP
 
 PREFERRED_ARRANGEMENT = [
     ['Chapter 2', ['Array', 'OrderedArray']],
@@ -46,12 +47,16 @@ def findVisualizations(filesAndDirectories, verbose=0):
     classes = set()
     for fileOrDir in filesAndDirectories:
         isDir = os.path.isdir(fileOrDir)
-        if verbose > 1:
-            print('Looking for "runVisualization()" in',
-                  'python files in {}'.format(fileOrDir) if isDir else isDir,
-                  file=sys.stderr)
         files = glob.glob(os.path.join(fileOrDir, '*.py')) if isDir else [
                    fileOrDir]
+        if verbose > 1:
+            print(
+                'Looking for "runVisualization()" in',
+                '{} python files in {}'.format(len(files), fileOrDir) if isDir
+                else fileOrDir,
+                file=sys.stderr)
+            if verbose > 2 and isDir:
+                print('Files:', '\n'.join(files), file=sys.stderr)
         for filename in [f for f in files 
                          if isStringInFile('runVisualization()', f)]:
             dirs = pathsep.split(os.path.normpath(os.path.dirname(filename)))
@@ -61,13 +66,24 @@ def findVisualizations(filesAndDirectories, verbose=0):
             if modulename:
                 try:
                     fullmodulename = '.'.join(dirs + [modulename])
+                    if verbose > 1:
+                        print('Attempting to import {} ... ' .format(
+                            fullmodulename), file=sys.stderr, end='')
                     module = import_module(fullmodulename)
                     if verbose > 1:
-                        print('Imported {} and looking for VisualizationApp'
+                        print('Imported. Looking for VisualizationApp'
                               .format(fullmodulename),
                               file=sys.stderr)
-                    classes |= set(findVisualizationClasses(
-                        module, verbose=verbose))
+                    newclasses = findVisualizationClasses(module, verbose)
+                    if verbose > 1:
+                        print('Found {} matching classes: {}'
+                              .format(len(newclasses), newclasses),
+                              file=sys.stderr)
+                        previouslyFound = set(newclasses) & classes
+                        if len(previouslyFound) > 0:
+                            print('Previously found:', previouslyFound,
+                                  file=sys.stderr)
+                    classes |= set(newclasses)
                 except ModuleNotFoundError:
                     if verbose > 0:
                         print('Unable to import module', modulename,
@@ -81,14 +97,10 @@ def isStringInFile(text, filename):
 def findVisualizationClasses(module, verbose=0):
     classes = []
     for name in dir(module):
-        this = getattr(module, name)
-        if isinstance(this, type(VisualizationApp)) and (
-                hasattr(this, 'runVisualization') and
-                len(this.__subclasses__()) == 0 and
-                this is not VisualizationApp):
-            if verbose > 1:
-                print('Found {}.{}, a subclass of VisualizationApp'.format(
-                    module.__name__, name))
+        this = getattr(module, name)          # Check if this 
+        if (isinstance(this, type(object)) and # is a class
+            issubclass(this, VAP) and this is not VAP and # a subclass of VAP
+            this.__module__ == module.__name__): # defined in ths module
             classes.append(this)
         elif verbose > 2:
             print('Ignoring {}.{} of type {}'.format(
@@ -227,10 +239,10 @@ def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
     top = Tk()
     top.title(title)
     ttk.Style().configure(
-        'TFrame', bg=getattr(VisualizationApp, 'DEFAULT_BG', 'white'))
+        'TFrame', bg=getattr(VAP, 'DEFAULT_BG', 'white'))
 
     if adjustForTrinket:
-        VisualizationApp.MIN_CODE_CHARACTER_HEIGHT = 9
+        VAP.MIN_CODE_CHARACTER_HEIGHT = 9
     restoreMenu = Canvas(top, height=MIN_MENUBAR_HEIGHT, bg='pink')
     restoreMenu.grid(row=0, column=0, sticky=(E, W, N, S))
     menubutton = Menubutton(top, text='Select Visualization',


### PR DESCRIPTION
This PR should close #185 by improving the logic for finding subclasses of VisualizationApp.   The old code didn't correctly check the subclass hierarchy and could ignore superclasses when subclasses were loaded first.

I've incorporated this into the Trinket running at https://johncanning.trinket.io/sites/runallvisualizations, which now correctly shows both the LinkedList and OrderedList apps.