### PR TITLE
Issue183 Add partition options in quicksort

### DIFF
--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -11,6 +11,9 @@ except ModuleNotFoundError:
       
 
 class AdvancedArraySort(SortingBase):
+    PIVOT_LINE_COLOR = 'VioletRed4'
+    PIVOT_LINE_WIDTH = 2
+    PIVOT_LINE_PAD = 3
 
     def __init__(self, title="Advanced Sorting", **kwargs):
         super().__init__(title=title, **kwargs)
@@ -56,113 +59,361 @@ class AdvancedArraySort(SortingBase):
     
     # SORTING METHODS 
 
-    def drawPartition(self, left, right):
-        bottom = self.canvas.create_line(self.ARRAY_X0 + self.CELL_WIDTH*left, self.ARRAY_Y0 + self.CELL_SIZE + 90,
-                           self.ARRAY_X0 + self.CELL_WIDTH*(right+1), self.ARRAY_Y0 + self.CELL_SIZE + 90, fill="red")
-        l = self.canvas.create_line(self.ARRAY_X0 + self.CELL_WIDTH*left, self.ARRAY_Y0 + self.CELL_SIZE + 80,
-                           self.ARRAY_X0 + self.CELL_WIDTH * left, self.ARRAY_Y0 + self.CELL_SIZE + 90, fill="red")
-        r = self.canvas.create_line(self.ARRAY_X0 + self.CELL_WIDTH * (right+1), self.ARRAY_Y0 + self.CELL_SIZE + 80,
-                           self.ARRAY_X0 + self.CELL_WIDTH * (right+1), self.ARRAY_Y0 + self.CELL_SIZE + 90, fill="red")
-
-        return bottom, l, r  
-            
-    def medianOfThree(self, left, right):
-        a = self.list
-
-        b = random.randint(left, right)
-        c = random.randint(left, right)
-        d = random.randint(left, right)
-        
-        dVal = a[d].val
-        bVal = a[b].val
-        cVal = a[c].val
-
-        if (dVal < bVal and bVal < cVal) or (cVal < bVal and bVal < dVal):
-            median = b
-        elif (bVal < dVal and dVal < cVal) or (cVal < dVal and dVal < bVal):
-            median = d
-        else:
-            median = c
-            
-        #a[median], a[right] = a[right], a[median]
-        self.swap(median, right)    
-    
-    def partitionIt(self, left, right):
-        callEnviron = self.createCallEnvironment()
-    
-        x = self.ARRAY_X0 + (self.CELL_SIZE / 2)
-        y0 = self.ARRAY_Y0 - 15
-        y1 = self.ARRAY_Y0 - 40
-
-        b, l, r = self.drawPartition(left, right)
-
-        self.medianOfThree(left, right)
-        a = self.list
-        pivot = a[right]
-        done = left
-        
-        doneArrow = self.createIndex(done, name="done", level=2)
-        pivotArrow = self.createIndex(right, name="pivot", level=3)
-
-        pivotCellObjects = []
-        pivotCellObjects.append(pivotArrow)
-
-        doneCellObjects = []
-        doneCellObjects.append(doneArrow)
-        
-        curArrow = self.createIndex(left, name="cur")
-        
-        callEnviron |= set(doneArrow)
-        callEnviron |= set(pivotArrow)
-        callEnviron |= set(curArrow)
-        callEnviron |= set((b, l, r))
-        
-        # for each position except for the pivot position
-        for cur in range(left, right):
-            # if the value at that position is smaller than the pivot
-            # swap it so it becomes the next value of the done part
-            if a[cur].val <= pivot.val:
-                #a[done], a[cur] = a[cur], a[done]
-                self.swap(done, cur)
-                done += 1                
-                self.moveItemsBy(doneArrow, (self.CELL_WIDTH, 0), sleepTime=0.02)
-
-            self.wait(0.2)
-
-            self.moveItemsBy(curArrow, (self.CELL_WIDTH, 0), sleepTime=0.02)
-
-        # Move the pivot into the correct place
-        #a[done], a[right] = a[right], a[done]
-        self.swap(done, right, aCellObjects=doneCellObjects, bCellObjects=pivotCellObjects)
-        
-        self.cleanUp(callEnviron)
-
-        # At this point, done is the location where the pivot value got placed
-        self.wait(0.1)
-        return done
-    
-    # Wrapper method 
-    def quickSort(self):
-        # Start animation
+    rightmostCode = '''
+def rightmost(self, lo={lo}, hi={hi}, key=identity):
+   return self.get(hi)
+'''
+    def rightmost(self, lo, hi, code=rightmostCode):
+        callEnviron = self.createCallEnvironment(code=code.format(**locals()))
         self.startAnimations()
-        callEnviron = self.createCallEnvironment()
+        self.highlightCode('return self.get(hi)', callEnviron, wait=0.1)
+        self.cleanUp(callEnviron)
+        return self.list[hi].val
+    
+    medianOfThreeCode = '''
+def medianOfThree(self, lo={lo}, hi={hi}, key=identity):
+   mid = (lo + hi) // 2
+   if key(self.get(lo)) > key(self.get(mid)):
+      self.swap(lo, mid)
+   if key(self.get(lo)) > key(self.get(hi)):
+      self.swap(lo, hi)
+   if key(self.get(hi)) > key(self.get(mid)):
+      self.swap(hi, mid)
+   return self.get(hi)
+'''
+    
+    def medianOfThree(self, lo, hi, code=medianOfThreeCode):
+        wait = 0.1
+        codeWait = 0.01
+        self.startAnimations()
+        callEnviron = self.createCallEnvironment(
+            code=code.format(**locals()), sleepTime=codeWait)
+
+        loIndex = self.createIndex(lo, 'lo')
+        hiIndex = self.createIndex(hi, 'hi')
+        callEnviron |= set(loIndex + hiIndex)
         
-        self.__quickSort(callEnviron)
+        self.highlightCode('mid = (lo + hi) // 2', callEnviron, wait=wait)
+        mid = (lo + hi) // 2
+        midIndex = self.createIndex(mid, 'mid', level=2)
+        callEnviron |= set(midIndex)
+
+        self.highlightCode('key(self.get(lo)) > key(self.get(mid))',
+                           callEnviron, wait=wait)
+        if self.list[lo].val > self.list[mid].val:
+            self.highlightCode('self.swap(lo, mid)', callEnviron)
+            self.swap(lo, mid)
+
+        self.highlightCode('key(self.get(lo)) > key(self.get(hi))',
+                           callEnviron, wait=wait)
+        if self.list[lo].val > self.list[hi].val:
+            self.highlightCode('self.swap(lo, hi)', callEnviron)
+            self.swap(lo, hi)
+
+        self.highlightCode('key(self.get(hi)) > key(self.get(mid))',
+                           callEnviron, wait=wait)
+        if self.list[hi].val > self.list[mid].val:
+            self.highlightCode('self.swap(hi, mid)', callEnviron)
+            self.swap(hi, mid)
+
+        self.highlightCode('return self.get(hi)', callEnviron, wait=wait)
+        self.cleanUp(callEnviron, sleepTime=codeWait)
+        return self.list[hi].val
+
+    __partCode = '''
+def __part(self, pivot={pivot}, lo={lo}, hi={hi}, key=identity):
+   while lo <= hi:
+      while (key(self.get(lo)) < pivot):
+         lo += 1
+      while (pivot < key(self.get(hi))):
+         hi -= 1
+      if lo >= hi:
+         return lo
+      self.swap(lo, hi)
+      lo, hi = lo + 1, hi - 1
+   return lo
+'''
+    def partition(self, pivot, lo, hi, code=__partCode):
+        wait = 0.1
+        codeWait = 0.01
+        self.startAnimations()
+        callEnviron = self.createCallEnvironment(
+            code=code.format(**locals()), sleepTime=codeWait)
+        
+        loIndex = self.createIndex(lo, 'lo')
+        hiIndex = self.createIndex(hi, 'hi', level=2)
+        callEnviron |= set(loIndex + hiIndex)
+        leftDelta = (-self.CELL_WIDTH, 0)
+        rightDelta = (self.CELL_WIDTH, 0)
+        
+        self.highlightCode('lo <= hi', callEnviron, wait=wait)
+        while lo <= hi:
+            self.highlightCode('key(self.get(lo)) < pivot', callEnviron,
+                               wait=wait)
+            while self.list[lo].val < pivot:
+                self.highlightCode('lo += 1', callEnviron)
+                lo += 1
+                self.moveItemsBy(loIndex, rightDelta, sleepTime=wait / 10)
+                
+                self.highlightCode('key(self.get(lo)) < pivot', callEnviron,
+                                   wait=wait)
+
+            self.highlightCode('pivot < key(self.get(hi))', callEnviron,
+                               wait=wait)
+            while hi > lo and pivot < self.list[hi].val:
+                self.highlightCode('hi -= 1', callEnviron)
+                hi -= 1
+                self.moveItemsBy(hiIndex, leftDelta, sleepTime=wait / 10)
+                
+                self.highlightCode('pivot < key(self.get(hi))', callEnviron,
+                                   wait=wait)
+                
+            self.highlightCode('lo >= hi', callEnviron, wait=wait)
+            if lo >= hi:
+                self.highlightCode('return lo', callEnviron, wait=wait)
+                self.cleanUp(callEnviron, sleepTime=codeWait)
+                return lo
+                
+            self.highlightCode('self.swap(lo, hi)', callEnviron)
+            self.swap(lo, hi)
+
+            self.highlightCode('lo, hi = lo + 1, hi - 1', callEnviron)
+            lo, hi = lo + 1, hi - 1
+            loCoords, hiCoords = self.indexCoords(lo), self.indexCoords(hi, 2)
+            self.moveItemsTo(
+                loIndex + hiIndex, 
+                (loCoords, loCoords[:2], hiCoords, hiCoords[:2]),
+                sleepTime=wait / 10)
+            
+            self.highlightCode('lo <= hi', callEnviron, wait=wait)
+        
+        self.highlightCode('return lo', callEnviron, wait=wait)
+        self.cleanUp(callEnviron, sleepTime=codeWait)
+        return lo
+
+    quicksortCode = '''
+def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
+   if hi is None:
+      hi = len(self) - 1
+   short = max(3, short)
+   if hi - lo + 1 <= short:
+      return self.insertionSort(lo, hi, key)
+   pivotItem = self.medianOfThree(lo, hi, key)
+   hipart = self.__part(key(pivotItem), lo + 1, hi - 1, key)
+   self.swap(hipart, hi)
+   self.quicksort(lo, hipart - 1, short, key)
+   self.quicksort(hipart + 1, hi, short, key)
+'''
+    
+    def quicksort(self, lo=0, hi=None, short=3, code=quicksortCode):
+            
+        # Start animation
+        wait = 0.1
+        codeWait = 0.01
+        self.startAnimations()
+        callEnviron = self.createCallEnvironment(
+            code=code.format(**locals()), sleepTime=codeWait)
+        
+        loIndex = self.createIndex(lo, 'lo')
+        callEnviron |= set(loIndex)
+
+        self.highlightCode('hi is None', callEnviron, wait=wait)
+        if hi is None:
+            self.highlightCode('hi = len(self) - 1', callEnviron, wait=wait)
+            hi = len(self.list) - 1
+            
+        hiIndex = self.createIndex(hi, 'hi', level=2)
+        callEnviron |= set(hiIndex)
+
+        self.highlightCode('short = max(3, short)', callEnviron, wait=wait)
+        short = max(3, short)
+
+        self.highlightCode('hi - lo + 1 <= short', callEnviron, wait=wait)
+        if hi - lo + 1 <= short:
+            self.highlightCode('return self.insertionSort(lo, hi, key)',
+                               callEnviron, wait=wait)
+            self.fadeNonLocalItems(callEnviron)
+            self.insertionSort(lo, hi)
+            self.cleanUp(callEnviron, sleepTime=codeWait)
+            self.restoreLocalItems(callEnviron)
+            return
+        
+        self.highlightCode('pivotItem = self.{}(lo, hi, key)'.format(
+            'medianOfThree' if  self.useMedianOf3.get() else 'rightmost'),
+                           callEnviron)
+        self.fadeNonLocalItems(callEnviron)
+        pivotItem = (self.medianOfThree(lo, hi) if self.useMedianOf3.get() else
+                     self.rightmost(lo, hi))
+        self.restoreLocalItems(callEnviron)
+
+        pivotPartition = self.createPivotPartition(lo, hi, pivotItem, hi)
+        callEnviron |= set(pivotPartition)
+                
+        self.highlightCode(
+            'hipart = self.__part(key(pivotItem), {}, hi - 1, key)'.format(
+                'lo + 1' if self.useMedianOf3.get() else 'lo'),
+            callEnviron)
+        self.fadeNonLocalItems(loIndex + hiIndex)
+        hipart = self.partition(
+            pivotItem, lo + (1 if self.useMedianOf3.get() else 0), hi - 1)
+        self.restoreLocalItems(loIndex + hiIndex)
+        
+        self.highlightCode('self.swap(hipart, hi)', callEnviron)
+        self.swap(hipart, hi)
+
+        for item in pivotPartition:
+            if item is not pivotPartition[-1]:
+                self.canvas.delete(item)
+            callEnviron.discard(item)
+
+        self.canvas.tag_raise('pivotPartition')
+        self.partitions.append(pivotPartition[-1])
+        self.highlightCode('self.quicksort(lo, hipart - 1, short, key)',
+                           callEnviron)
+        self.fadeNonLocalItems(loIndex + hiIndex)
+        self.quicksort(lo, hipart - 1, short, code)
+        self.restoreLocalItems(loIndex + hiIndex)
+        self.canvas.tag_raise('pivotPartition')
+
+        self.highlightCode('self.quicksort(hipart + 1, hi, short, key)',
+                           callEnviron)
+        self.fadeNonLocalItems(loIndex + hiIndex)
+        self.quicksort(hipart + 1, hi, short, code)
+        self.restoreLocalItems(loIndex + hiIndex)
+        self.canvas.tag_raise('pivotPartition')
         
         # Finish animation
-        self.cleanUp()
-    
-    def __quickSort(self, callEnviron, left=-1, right=-1):
-        # initialize things if method was called without args
-        if left == -1:
-            left = 0
-            right = len(self.list) - 1
+        self.cleanUp(callEnviron, sleepTime=codeWait)
 
-        # there has to be at least two elements
-        if left < right:
-            partition = self.partitionIt(left, right)
-            self.__quickSort(callEnviron, left, partition - 1)
-            self.__quickSort(callEnviron, partition + 1, right)    
+    def createPivotPartition(
+            self, lo, hi, pivot, pivotIndex,
+            font=VisualizationApp.VARIABLE_FONT, 
+            labelColor=VisualizationApp.VARIABLE_COLOR, 
+            tags=['pivotPartition']):
+        pivotCoords, loCoords, hiCoords = (
+            self.canvas.coords(self.list[idx].items[0]) for idx in
+            (pivotIndex, lo, hi))
+        
+        pad = self.PIVOT_LINE_PAD
+
+        labels = ['pivot', str(pivot), '[{}, {}]'.format(lo, hi)]
+        widths = [self.textWidth(font, label) for label in labels]
+        height = abs(font[1])
+        maxWidth = max(*widths)
+        lbls = tuple(self.canvas.create_text(
+            self.ARRAY_X0 - maxWidth // 2, pivotCoords[3] + (i - 1) * height,
+            text=labels[i], font=font, fill=labelColor)
+                  for i in range(len(labels)))
+        line = self.canvas.create_line(
+            loCoords[0] - pad, pivotCoords[3], 
+            hiCoords[2] + pad, pivotCoords[3], tags=tags, dash=(5, 5),
+            fill=self.PIVOT_LINE_COLOR, width=self.PIVOT_LINE_WIDTH)
+        if not self.showPartitions:
+            for item in lbls + (line,):
+                self.canvas.coords(
+                    item, multiply_vector(self.canvas.coords(item), -1))
+        return lbls + (line,)
+
+    def showPartitionsControlCoords(self):
+        gap = 10
+        size = 16
+        canvasDims = self.widgetDimensions(self.canvas)
+        return (gap, canvasDims[1] - gap - size, 
+                gap + size, canvasDims[1] - gap)
+    
+    def createShowPartitionsControl(self):
+        coords = self.showPartitionsControlCoords()
+        box = self.canvas.create_rectangle(
+            *coords, fill=self.DEFAULT_BG, outline=self.CONTROLS_COLOR, width=2)
+        center = divide_vector(add_vector(coords[:2], coords[2:]), 2)
+        self.showPartitionsCheck = self.canvas.create_text(
+            *(center if self.showPartitions else multiply_vector(center, -1)),
+            text='✓', fill=self.CONTROLS_COLOR, font=self.CONTROLS_FONT)
+        label = self.canvas.create_text(
+            *add_vector(center, (coords[2] - coords[0], 0)), anchor=W,
+            text='Show pivot partitions', fill=self.CONTROLS_COLOR, 
+            font=self.CONTROLS_FONT)
+        for item in (box, self.showPartitionsCheck, label):
+            self.canvas.tag_bind(item, '<Button>', self.toggleShowPartitons)
+
+    def toggleShowPartitons(self, event=None):
+        self.showPartitions = not self.showPartitions
+        sign = 1 if self.showPartitions else -1
+        for item in self.canvas.find_withtag('pivotPartition') + (
+                self.showPartitionsCheck,):
+            self.canvas.coords(
+                item, *(sign * abs(c) for c in self.canvas.coords(item)))
+        
+    def insertionSort(self, lo, hi):
+        'Sort a short range of cells using insertion sort (no code)'
+        wait = 0.1
+        self.startAnimations()
+        callEnviron = self.createCallEnvironment()
+        n = len(self.list)
+
+        # make an index arrow for the outer loop
+        outer = lo + 1
+        outerIndex = self.createIndex(outer, "outer", level=2)
+        callEnviron |= set(outerIndex)
+
+        # make an index arrow that points to the next cell to check
+        innerIndex = self.createIndex(outer, "inner", level=1)
+        callEnviron |= set(innerIndex)
+        tempVal, label = None, None
+
+        # All items beyond the outer index have not been sorted
+        while outer <= hi:
+
+            # Store item at outer index in temporary mark variable
+            temp = self.list[outer].val
+
+            if tempVal:
+                tempVal, _ = self.assignToTemp(
+                    outer, callEnviron, varName="temp", existing=label)
+            else:
+                tempVal, label = self.assignToTemp(
+                    outer, callEnviron, varName="temp")
+                callEnviron.add(label)
+
+            # Inner loop starts at marked temporary item
+            inner = outer
+
+            # Move inner index arrow to point at cell to check
+            centerX0 = self.cellCenter(inner)[0]
+            deltaX = centerX0 - self.canvas.coords(innerIndex[0])[0]
+            if deltaX != 0:
+                self.moveItemsBy(innerIndex, (deltaX, 0), sleepTime=wait / 10)
+
+            # Loop down until we find an item less than or equal to the mark
+            while inner > lo and temp < self.list[inner - 1].val:
+
+                # Shift cells right that are greater than mark
+                self.assignElement(inner - 1, inner, callEnviron)
+
+                # Move inner index arrow to point at next cell to check
+                inner -= 1
+                centerX0 = self.cellCenter(inner)[0]
+                deltaX = centerX0 - self.canvas.coords(innerIndex[0])[0]
+                if deltaX != 0:
+                    self.moveItemsBy(
+                        innerIndex, (deltaX, 0), sleepTime=wait / 10) 
+
+            # Delay to show discovery of insertion point for mark
+            self.wait(wait)
+
+            # Copy marked temporary value to insertion point
+            self.assignFromTemp(inner, tempVal, None)
+
+            # Take it out of the cleanup set since it should persist
+            callEnviron -= set(tempVal.items)
+
+            # Advance outer loop
+            outer += 1
+            self.moveItemsBy(outerIndex, (self.CELL_WIDTH, 0), 
+                             sleepTime=wait / 10)
+
+        # Animation stops
+        self.cleanUp(callEnviron)
 
     shellSortCode = """
 def shellSort(self):
@@ -278,7 +529,7 @@ def shellSort(self):
     def makeButtons(self, maxRows=4):
         buttons, vcmd = super().makeButtons(maxRows=maxRows)
         quicksortButton = self.addOperation(
-            "Quicksort", lambda: self.quickSort(), maxRows=maxRows,
+            "Quicksort", lambda: self.clickQuicksort(), maxRows=maxRows,
             helpText='Sort items using quicksort algorithm')
         self.useMedianOf3 = IntVar()
         self.useMedianOf3.set(1)
@@ -292,6 +543,14 @@ def shellSort(self):
         self.addAnimationButtons(maxRows=maxRows)
         buttons += [quicksortButton, shellSortButton]
         return buttons  # Buttons managed by play/pause/stop controls
+
+    def clickQuicksort(self):
+        self.partitions = []
+        self.showPartitions = True
+        self.createShowPartitionsControl()
+        self.quicksort(code=self.quicksortCode if self.useMedianOf3.get() else
+                       self.quicksortCode.replace('medianOfThree', 'rightmost')
+                       .replace('lo + 1,', 'lo,'))
 
     def clickUseMedianOf3(self):
         pass

--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -318,7 +318,7 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
         self.restoreLocalItems(loIndex + hiIndex + hipartIndex)
         self.canvas.tag_raise('pivotPartition')
         
-        # Finish animation
+        self.highlightCode([], callEnviron)
         self.cleanUp(callEnviron, sleepTime=codeWait)
 
     def createPivotPartition(

--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -280,12 +280,21 @@ def shellSort(self):
         quicksortButton = self.addOperation(
             "Quicksort", lambda: self.quickSort(), maxRows=maxRows,
             helpText='Sort items using quicksort algorithm')
+        self.useMedianOf3 = IntVar()
+        self.useMedianOf3.set(1)
+        useMedianOf3Button = self.addOperation(
+            "Use median of 3", self.clickUseMedianOf3, buttonType=Checkbutton,
+            variable=self.useMedianOf3, maxRows=maxRows,
+            helpText='Use median of 3 to select pivot in quicksort algorithm')
         shellSortButton = self.addOperation(
             "Shellsort", lambda: self.shellSort(), maxRows=maxRows,
             helpText='Sort items using shellsort algorithm')
         self.addAnimationButtons(maxRows=maxRows)
         buttons += [quicksortButton, shellSortButton]
         return buttons  # Buttons managed by play/pause/stop controls
+
+    def clickUseMedianOf3(self):
+        pass
         
 if __name__ == '__main__':
     random.seed(3.14159)  # Use fixed seed for testing consistency

--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -275,35 +275,8 @@ def shellSort(self):
         self.cleanUp(callEnviron)
         return nShifts
 
-    def makeButtons(self, maxRows=3):
-        vcmd = (self.window.register(numericValidate),
-                '%d', '%i', '%P', '%s', '%S', '%v', '%V', '%W')
-        insertButton = self.addOperation(
-            "Insert", lambda: self.clickInsert(), numArguments=1,
-            validationCmd=vcmd, maxRows=maxRows,
-            argHelpText=['item key'], helpText='Insert item in array')
-        searchButton = self.addOperation(
-            "Search", lambda: self.clickSearch(), numArguments=1,
-            validationCmd=vcmd, maxRows=maxRows,
-            argHelpText=['item key'], helpText='Search for item in array')
-        deleteButton = self.addOperation(
-            "Delete", lambda: self.clickDelete(), numArguments=1,
-            validationCmd=vcmd, maxRows=maxRows,
-            argHelpText=['item key'], helpText='Delete array item')
-        newButton = self.addOperation(
-            "New", lambda: self.clickNew(), numArguments=1,
-            validationCmd=vcmd, maxRows=maxRows, 
-            argHelpText=['number of cells'],
-            helpText='Create new empty array')
-        randomFillButton = self.addOperation(
-            "Random Fill", lambda: self.randomFill(), maxRows=maxRows,
-            helpText='Fill all array cells with random keys')
-        shuffleButton = self.addOperation(
-            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
-            helpText='Shuffle position of all items')
-        deleteRightmostButton = self.addOperation(
-            "Delete Rightmost", lambda: self.deleteLast(), maxRows=maxRows,
-            helpText='Delete last array item')
+    def makeButtons(self, maxRows=4):
+        buttons, vcmd = super().makeButtons(maxRows=maxRows)
         quicksortButton = self.addOperation(
             "Quicksort", lambda: self.quickSort(), maxRows=maxRows,
             helpText='Sort items using quicksort algorithm')
@@ -311,9 +284,7 @@ def shellSort(self):
             "Shellsort", lambda: self.shellSort(), maxRows=maxRows,
             helpText='Sort items using shellsort algorithm')
         self.addAnimationButtons(maxRows=maxRows)
-        buttons = [insertButton, searchButton, deleteButton, newButton, 
-                   randomFillButton, shuffleButton, deleteRightmostButton,
-                   quicksortButton]
+        buttons += [quicksortButton, shellSortButton]
         return buttons  # Buttons managed by play/pause/stop controls
         
 if __name__ == '__main__':

--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -260,6 +260,7 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
         
         self.highlightCode('self.swap(hipart, hi)', callEnviron)
         self.swap(hipart, hi)
+        pivotMark = self.createPivotMark(hipart)
 
         for item in pivotPartition:
             if item is not pivotPartition[-1]:
@@ -313,6 +314,20 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
                 self.canvas.coords(
                     item, multiply_vector(self.canvas.coords(item), -1))
         return lbls + (line,)
+    
+    def createPivotMark(
+            self, pivotIndex, font=None, 
+            color=VisualizationApp.VARIABLE_COLOR, tags=['pivotPartition']):
+        if font is None:
+            font = (self.VARIABLE_FONT[0], self.VARIABLE_FONT[1] * 2)
+        cellCoords = self.cellCoords(pivotIndex)
+        markCoords = ((cellCoords[0] + cellCoords[2]) // 2,
+                      cellCoords[3] + abs(font[1]) // 2)
+        mark = self.canvas.create_text(
+            *(markCoords if self.showPartitions else 
+              multipy_vector(markCoords, -1)), tags=tags, text='◭',
+            font=font, fill=color)
+        return mark
 
     def showPartitionsControlCoords(self):
         gap = 10

--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -279,7 +279,7 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
 
         pivotPartition = self.createPivotPartition(lo, hi, pivotItem, hi)
         callEnviron |= set(pivotPartition)
-        bottomCallEnviron.add(pivotPartition[-1])
+        # bottomCallEnviron.add(pivotPartition[-1])
                 
         self.highlightCode(
             'hipart = self.__part(key(pivotItem), {}, hi - 1, key)'.format(
@@ -297,12 +297,11 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
         pivotMark = self.createPivotMark(hipart, pivotItem)
         bottomCallEnviron |= set(pivotMark)
 
-        for item in pivotPartition[:-1]:
+        for item in pivotPartition:
             self.canvas.delete(item)
             callEnviron.discard(item)
+        pivotPartition = ()
 
-        self.canvas.tag_raise('pivotPartition')
-        self.partitions.append(pivotPartition[-1])
         self.highlightCode('self.quicksort(lo, hipart - 1, short, key)',
                            callEnviron)
         self.fadeNonLocalItems(loIndex + hiIndex + hipartIndex)
@@ -363,10 +362,7 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
         markCoords = (centerX, cellCoords[3] + abs(font[1]) // 2)
         mark = self.canvas.create_text(
             *markCoords, tags=tags, text='◭', font=font, fill=color)
-        line = self.canvas.create_line(
-            centerX, fillCoords[3], centerX, cellCoords[3],
-            tags=tags, fill=color, width=self.PIVOT_LINE_WIDTH)
-        items = (mark, line)
+        items = (mark,)
         if not self.showPartitions:
             for item in items:
                 self.canvas.coords(

--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -350,18 +350,19 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
                 self.canvas.coords(
                     item, multiply_vector(self.canvas.coords(item), -1))
         return lbls + (line,)
-    
-    def createPivotMark(
-            self, pivotIndex, pivotValue, font=None,
-            color=VisualizationApp.VARIABLE_COLOR, tags=['pivotPartition']):
-        if font is None:
-            font = (self.VARIABLE_FONT[0], self.VARIABLE_FONT[1] * 2)
+
+    def pivotMarkCoords(self, pivotIndex):
         cellCoords = self.cellCoords(pivotIndex)
-        fillCoords = self.fillCoords(pivotValue, cellCoords)
         centerX = (cellCoords[0] + cellCoords[2]) // 2
-        markCoords = (centerX, cellCoords[3] + abs(font[1]) // 2)
-        mark = self.canvas.create_text(
-            *markCoords, tags=tags, text='◭', font=font, fill=color)
+        top = cellCoords[3] + 10
+        dX, dY = 5, 15
+        return (centerX, top, centerX - dX, top + dY, centerX + dX, top + dY)
+        
+    def createPivotMark(
+            self, pivotIndex, pivotValue, 
+            color=VisualizationApp.VARIABLE_COLOR, tags=['pivotPartition']):
+        mark = self.canvas.create_polygon(
+            *self.pivotMarkCoords(pivotIndex), tags=tags, fill=color, width=0)
         items = (mark,)
         if not self.showPartitions:
             for item in items:

--- a/PythonVisualizations/TextHighlight.py
+++ b/PythonVisualizations/TextHighlight.py
@@ -13,7 +13,7 @@ class CodeHighlightBlock(object):
                  code,       # a unique prefix to highlight snippets in it,
                  textWidget): # and tags the snippets when refreenced
        self.code = code.strip()
-       self.lines = self.code.split('\n')
+       self.lines = self.code.split('\n') if len(code) > 0 else []
        self.cache = {}
        self.textWidget = textWidget
        self.prefix = '{:04d}-'.format(self._counter)

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -90,6 +90,7 @@ class VisualizationApp(object):  # Base class for Python visualizations
     VALUE_COLOR = 'black'
     VARIABLE_FONT = ('Courier', FONT_SIZE * 8 // 10)
     VARIABLE_COLOR = 'brown3'
+    NONLOCAL_VARIABLE_COLOR = 'bisque'
     FOUND_FONT = ('Helvetica', FONT_SIZE)
     FOUND_COLOR = 'green2'
     OPERATIONS_BG = 'beige'

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -100,6 +100,7 @@ class VisualizationApp(object):  # Base class for Python visualizations
     CODE_HIGHLIGHT = 'yellow'
     EXCEPTION_HIGHLIGHT = 'orange'
     CONTROLS_FONT = ('Helvetica', -12)
+    CONTROLS_COLOR = 'blue'
     HINT_FONT = CONTROLS_FONT + ('italic',)
     HINT_FG = 'blue'
     HINT_BG = 'beige'
@@ -759,6 +760,18 @@ class VisualizationApp(object):  # Base class for Python visualizations
             self.canvas.tag_bind(newItem, eventType,
                                  self.canvas.tag_bind(canvasitem, eventType))
         return newItem
+
+    def fadeNonLocalItems(self, items, color=NONLOCAL_VARIABLE_COLOR):
+        'Set fill color of non-local variable canvas items to a faded color'
+        self.setItemsFillColor(items, color)
+        
+    def restoreLocalItems(self, items, color=VARIABLE_COLOR):
+        'Restore fill color of local variable canvas items to normal'
+        self.setItemsFillColor(items, color)
+
+    def setItemsFillColor(self, items, color):
+        for item in items:
+            self.canvas.itemconfigure(item, fill=color)
 
     #####################################################################
     #                                                                   #

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -667,7 +667,9 @@ class VisualizationApp(object):  # Base class for Python visualizations
                 self.canvas.delete(thing)
             elif isinstance(thing, CodeHighlightBlock) and self.codeText:
                 self.codeText.configure(state=NORMAL)
-                last_line = int(float(self.codeText.index(END)))
+                last_line = int(
+                    float(self.codeText.index(END)) if len(thing.lines) > 0
+                    else 0)
                 for i in range(1, min(last_line, len(thing.lines) + 2)):
                     if self.codeText:
                         self.codeText.delete('1.0', '2.0')


### PR DESCRIPTION
This PR should close #183 by adding a visualization of the partition line for the current recursive call to quicksort.  It also draws triangles to mark where the pivots are placed.  The median of three method is an option controlled by a checkbutton.