### PR TITLE
Issue187 Move cells down in Shellsort

### DIFF
--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -419,30 +419,27 @@ def shellSort(self):
             helpText='Create new empty array')
         randomFillButton = self.addOperation(
             "Random Fill", lambda: self.randomFill(), maxRows=maxRows,
-            helpText='Fill all array cells with random keys')
+            helpText='Fill empty array cells with random keys')
         increasingFillButton = self.addOperation(
             "Increasing Fill", lambda: self.linearFill(), maxRows=maxRows,
-            helpText='Fill all array cells with increasing keys')
+            helpText='Fill empty array cells with increasing keys')
         decreasingFillButton = self.addOperation(
             "Decreasing Fill", lambda: self.linearFill(False), maxRows=maxRows,
-            helpText='Fill all array cells with decreasing keys')
-        shuffleButton = self.addOperation(
-            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
-            helpText='Shuffle position of all items')
+            helpText='Fill empty array cells with decreasing keys')
         deleteRightmostButton = self.addOperation(
             "Delete Rightmost", lambda: self.deleteLast(), maxRows=maxRows,
             helpText='Delete last array item')
+        shuffleButton = self.addOperation(
+            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
+            helpText='Shuffle position of all items')
         quicksortButton = self.addOperation(
             "Quicksort", lambda: self.quickSort(), maxRows=maxRows,
             helpText='Sort items using quicksort algorithm')
         shellSortButton = self.addOperation(
             "Shellsort", lambda: self.shellSort(), maxRows=maxRows,
             helpText='Sort items using shellsort algorithm')
+        buttons = [btn for btn in self.opButtons]
         self.addAnimationButtons(maxRows=maxRows)
-        buttons = [insertButton, searchButton, deleteButton, newButton, 
-                   randomFillButton, decreasingFillButton, increasingFillButton,
-                   shuffleButton, deleteRightmostButton,
-                   quicksortButton, shellSortButton]
         return buttons  # Buttons managed by play/pause/stop controls
         
 if __name__ == '__main__':

--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -397,7 +397,7 @@ def shellSort(self):
                 x0, y0, x1, y0,
                 x1, y0 - height // 2, x1, y0 + height // 2)
     
-    def makeButtons(self, maxRows=3):
+    def makeButtons(self, maxRows=4):
         vcmd = (self.window.register(numericValidate),
                 '%d', '%i', '%P', '%s', '%S', '%v', '%V', '%W')
         insertButton = self.addOperation(
@@ -420,6 +420,12 @@ def shellSort(self):
         randomFillButton = self.addOperation(
             "Random Fill", lambda: self.randomFill(), maxRows=maxRows,
             helpText='Fill all array cells with random keys')
+        increasingFillButton = self.addOperation(
+            "Increasing Fill", lambda: self.linearFill(), maxRows=maxRows,
+            helpText='Fill all array cells with increasing keys')
+        decreasingFillButton = self.addOperation(
+            "Decreasing Fill", lambda: self.linearFill(False), maxRows=maxRows,
+            helpText='Fill all array cells with decreasing keys')
         shuffleButton = self.addOperation(
             "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
             helpText='Shuffle position of all items')
@@ -434,8 +440,9 @@ def shellSort(self):
             helpText='Sort items using shellsort algorithm')
         self.addAnimationButtons(maxRows=maxRows)
         buttons = [insertButton, searchButton, deleteButton, newButton, 
-                   randomFillButton, shuffleButton, deleteRightmostButton,
-                   quicksortButton]
+                   randomFillButton, decreasingFillButton, increasingFillButton,
+                   shuffleButton, deleteRightmostButton,
+                   quicksortButton, shellSortButton]
         return buttons  # Buttons managed by play/pause/stop controls
         
 if __name__ == '__main__':

--- a/PythonVisualizations/Array.py
+++ b/PythonVisualizations/Array.py
@@ -20,15 +20,42 @@ class Array(SortingBase):
         # The display items representing these array cells are created later
         for i in range(self.size - 1):
             self.list.append(drawnValue(random.randrange(self.valMax)))
+        self.makeButtons()
+
         self.display()
 
-        self.buttons = self.makeButtons()
 
     # Button functions
-    def makeButtons(self, maxRows=4):
-        buttons, vcmd = super().makeButtons(maxRows=maxRows)
-        self.addAnimationButtons()
-        return buttons
+    def makeButtons(self, maxRows=3):
+        vcmd = (self.window.register(numericValidate),
+                '%d', '%i', '%P', '%s', '%S', '%v', '%V', '%W')
+        insertButton = self.addOperation(
+            "Insert", lambda: self.clickInsert(), numArguments=1,
+            validationCmd=vcmd, maxRows=maxRows,
+            argHelpText=['item key'], helpText='Insert item in array')
+        searchButton = self.addOperation(
+            "Search", lambda: self.clickSearch(), numArguments=1,
+            validationCmd=vcmd, maxRows=maxRows,
+            argHelpText=['item key'], helpText='Search for item in array')
+        deleteButton = self.addOperation(
+            "Delete", lambda: self.clickDelete(), numArguments=1,
+            validationCmd=vcmd, maxRows=maxRows,
+            argHelpText=['item key'], helpText='Delete array item')
+        newButton = self.addOperation(
+            "New", lambda: self.clickNew(), numArguments=1,
+            validationCmd=vcmd, maxRows=maxRows, 
+            argHelpText=['number of cells'],
+            helpText='Create new empty array')
+        traverseButton = self.addOperation(
+            "Traverse", lambda: self.traverse(), maxRows=maxRows,
+            helpText='Traverse all array cells once')
+        randomFillButton = self.addOperation(
+            "Random Fill", lambda: self.randomFill(), maxRows=maxRows,
+            helpText='Fill empty array cells with random keys')
+        deleteRightmostButton = self.addOperation(
+            "Delete Rightmost", lambda: self.deleteLast(), maxRows=maxRows,
+            helpText='Delete last array item')
+        self.addAnimationButtons(maxRows=maxRows)
         
     def clickInsert(self):
         val = self.validArgument()

--- a/PythonVisualizations/Mergesort.py
+++ b/PythonVisualizations/Mergesort.py
@@ -308,7 +308,7 @@ def merge(self, lo={lo}, mid={mid}, hi={hi}):
         for i, cell in enumerate(self.arrayCells):
             self.canvas.coords(cell, self.arrayCellCoords(i))
                 
-    def makeButtons(self, maxRows=3):
+    def makeButtons(self, maxRows=4):
         vcmd = (self.window.register(numericValidate),
                 '%d', '%i', '%P', '%s', '%S', '%v', '%V', '%W')
         insertButton = self.addOperation(
@@ -328,22 +328,26 @@ def merge(self, lo={lo}, mid={mid}, hi={hi}):
             validationCmd=vcmd, maxRows=maxRows, 
             argHelpText=['number of cells'],
             helpText='Create new empty array')
-        mergesortButton = self.addOperation(
-            "Mergesort", lambda: self.mergesortInit(), maxRows=maxRows,
-            helpText='Sort items using mergesort')
         randomFillButton = self.addOperation(
             "Random Fill", lambda: self.randomFill(), maxRows=maxRows,
-            helpText='Fill all array cells with random keys')
-        shuffleButton = self.addOperation(
-            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
-            helpText='Shuffle position of all items')
+            helpText='Fill empty array cells with random keys')
+        increasingFillButton = self.addOperation(
+            "Increasing Fill", lambda: self.linearFill(), maxRows=maxRows,
+            helpText='Fill empty array cells with increasing keys')
+        decreasingFillButton = self.addOperation(
+            "Decreasing Fill", lambda: self.linearFill(False), maxRows=maxRows,
+            helpText='Fill empty array cells with decreasing keys')
         deleteRightmostButton = self.addOperation(
             "Delete Rightmost", lambda: self.deleteLast(), maxRows=maxRows,
             helpText='Delete last array item')
+        shuffleButton = self.addOperation(
+            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
+            helpText='Shuffle position of all items')
+        mergesortButton = self.addOperation(
+            "Mergesort", lambda: self.mergesortInit(), maxRows=maxRows,
+            helpText='Sort items using mergesort')
+        buttons = [btn for btn in self.opButtons]
         self.addAnimationButtons(maxRows=maxRows)
-        buttons = [insertButton, searchButton, deleteButton, newButton, 
-                   randomFillButton, shuffleButton, deleteRightmostButton,
-                   mergesortButton]
         return buttons  # Buttons managed by play/pause/stop controls
 
     def new(self, val):

--- a/PythonVisualizations/SimpleSorting.py
+++ b/PythonVisualizations/SimpleSorting.py
@@ -245,7 +245,7 @@ def selectionSort(self):
         self.highlightCode([], callEnviron)
         self.cleanUp(callEnviron)
 
-    def makeButtons(self, maxRows=3):
+    def makeButtons(self, maxRows=4):
         vcmd = (self.window.register(numericValidate),
                 '%d', '%i', '%P', '%s', '%S', '%v', '%V', '%W')
         insertButton = self.addOperation(
@@ -267,13 +267,19 @@ def selectionSort(self):
             helpText='Create new empty array')
         randomFillButton = self.addOperation(
             "Random Fill", lambda: self.randomFill(), maxRows=maxRows,
-            helpText='Fill all array cells with random keys')
-        shuffleButton = self.addOperation(
-            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
-            helpText='Shuffle position of all items')
+            helpText='Fill empty array cells with random keys')
+        increasingFillButton = self.addOperation(
+            "Increasing Fill", lambda: self.linearFill(), maxRows=maxRows,
+            helpText='Fill empty array cells with increasing keys')
+        decreasingFillButton = self.addOperation(
+            "Decreasing Fill", lambda: self.linearFill(False), maxRows=maxRows,
+            helpText='Fill empty array cells with decreasing keys')
         deleteRightmostButton = self.addOperation(
             "Delete Rightmost", lambda: self.deleteLast(), maxRows=maxRows,
             helpText='Delete last array item')
+        shuffleButton = self.addOperation(
+            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
+            helpText='Shuffle position of all items')
         bubbleSortButton = self.addOperation(
             "Bubble Sort", lambda: self.bubbleSort(), maxRows=maxRows,
             helpText='Sort array using bubble sort')
@@ -283,10 +289,8 @@ def selectionSort(self):
         insertionSortButton = self.addOperation(
             "Insertion Sort", lambda: self.insertionSort(), maxRows=maxRows,
             helpText='Sort array using insertion sort')
+        buttons = [btn for btn in self.opButtons]
         self.addAnimationButtons(maxRows=maxRows)
-        buttons = [insertButton, searchButton, deleteButton, newButton, 
-                   randomFillButton, shuffleButton, deleteRightmostButton,
-                   bubbleSortButton, selectionSortButton, insertionSortButton]
         return buttons  # Buttons managed by play/pause/stop controls
 
 if __name__ == '__main__':

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -311,8 +311,13 @@ def insert(self, item={val}):
     def randomFill(self):
         callEnviron = self.createCallEnvironment()        
 
-        self.list = [
-            drawnValue(random.randrange(self.valMax)) for i in range(self.size)]
+        toFill = self.size - len(self.list)
+        if toFill > 0:
+            self.list.extend([
+                drawnValue(random.randrange(self.valMax)) 
+                for i in range(toFill)])
+        else:
+            self.setMessage('Array is already full')
         
         self.display(showNItems=self.nItems)
         self.cleanUp(callEnviron)
@@ -320,12 +325,15 @@ def insert(self, item={val}):
     def linearFill(self, increasing=True):
         callEnviron = self.createCallEnvironment()        
 
-        self.list = [
-            drawnValue(
-                int((i if increasing else (self.size - 1 - i)) * self.valMax /
-                    (self.size - 1)))
-            for i in range(self.size)]
-        
+        toFill = self.size - len(self.list)
+        if toFill > 0:
+            self.list.extend([
+                drawnValue(
+                    int((i if increasing else max(1, toFill - 1) - i) *
+                        self.valMax / max(1, toFill - 1)))
+                for i in range(toFill)])
+        else:
+            self.setMessage('Array is already full')
         self.display(showNItems=self.nItems)
         self.cleanUp(callEnviron)
         
@@ -863,16 +871,20 @@ def traverse(self, function=print):
             helpText='Traverse all array cells once')
         randomFillButton = self.addOperation(
             "Random Fill", lambda: self.randomFill(), maxRows=maxRows,
-            helpText='Fill all array cells with random keys')
-        shuffleButton = self.addOperation(
-            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
-            helpText='Shuffle position of all items')
+            helpText='Fill empty array cells with random keys')
+        increasingFillButton = self.addOperation(
+            "Increasing Fill", lambda: self.linearFill(), maxRows=maxRows,
+            helpText='Fill empty array cells with increasing keys')
+        decreasingFillButton = self.addOperation(
+            "Decreasing Fill", lambda: self.linearFill(False), maxRows=maxRows,
+            helpText='Fill empty array cells with decreasing keys')
         deleteRightmostButton = self.addOperation(
             "Delete Rightmost", lambda: self.deleteLast(), maxRows=maxRows,
             helpText='Delete last array item')
-        buttons = [insertButton, searchButton, deleteButton, newButton, 
-                   traverseButton, randomFillButton, shuffleButton,
-                   deleteRightmostButton]
+        shuffleButton = self.addOperation(
+            "Shuffle", lambda: self.shuffle(), maxRows=maxRows,
+            helpText='Shuffle position of all items')
+        buttons = [btn for btn in self.opButtons]
         return buttons, vcmd  # Buttons managed by play/pause/stop controls    
     
     def validArgument(self, valMax=None):

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -82,7 +82,8 @@ class SortingBase(VisualizationApp):
         tempPos = self.tempCoords(index)
         return (tempPos[0] + tempPos[2]) // 2, tempPos[1] - abs(font[1])
     
-    def assignToTemp(self, index, callEnviron, varName="temp", existing=None):
+    def assignToTemp(self, index, callEnviron, varName="temp", existing=None,
+                     sleepTime=0.02):
         """Assign indexed cell to a temporary variable named varName.
         Animate value moving to the temporary variable below the array.
         Return a drawnValue for the new temporary value and a text item for
@@ -109,24 +110,25 @@ class SortingBase(VisualizationApp):
             callEnviron.add(tempLabel)
 
         delta = (tempLabelPos[0] - cellXCenter, tempPos[1] - posCell[1])
-        self.moveItemsBy(copyItems, delta, sleepTime=0.02)
+        self.moveItemsBy(copyItems, delta, sleepTime=sleepTime)
 
         return drawnValue(fromValue.val, *copyItems), tempLabel
 
-    def assignFromTemp(self, index, temp, templabel, delete=True):
+    def assignFromTemp(self, index, temp, templabel, delete=True,
+                       sleepTime=0.04):
         """Assign a temporary drawnValue to the indexed array cell by
         moving it into position on top of the array cell
         Delete the temporary label if requested.
         """
 
-        toCellCoords = self.fillCoords(temp.val, self.cellCoords(index))
-        toCellCenter = self.cellCenter(index)
+        toCellCoords = self.fillCoords(temp.val, self.currentCellCoords(index))
+        toCellCenter = self.currentCellCenter(index)
         tempCellCoords = self.canvas.coords(temp.items[0])
         deltaX = toCellCoords[0] - tempCellCoords[0]
         startAngle = 45 * 500 / (500 + abs(deltaX)) * (-1 if deltaX < 0 else 1)
 
         self.moveItemsOnCurve(
-            temp.items, (toCellCoords, toCellCenter), sleepTime=0.04,
+            temp.items, (toCellCoords, toCellCenter), sleepTime=sleepTime,
             startAngle=startAngle)
 
         if delete:
@@ -803,6 +805,8 @@ def traverse(self, function=print):
         self.fixCells()
     
     def fixCells(self):  # Move canvas display items to exact cell coords
+        for index, ac in enumerate(self.arrayCells):
+            self.canvas.coords(ac, self.arrayCellCoords(index))
         for i, dValue in enumerate(self.list):
             for item, coords in zip(dValue.items,
                                     (self.fillCoords(dValue.val,

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -170,10 +170,10 @@ class SortingBase(VisualizationApp):
         space = self.CELL_SIZE * 1 // 10
         x = cell_center[0]
         if level > 0:
-            y0 = cell_coords[1] - 2 * space - level * level_space
+            y0 = cell_coords[1] - space - level * level_space
             y1 = cell_coords[1] - space
         else:
-            y0 = cell_coords[3] + 2 * space - level * level_space
+            y0 = cell_coords[3] + space - level * level_space
             y1 = cell_coords[3] + space
         return x, y0, x, y1
         

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -114,6 +114,10 @@ class SortingBase(VisualizationApp):
         return drawnValue(fromValue.val, *copyItems), tempLabel
 
     def assignFromTemp(self, index, temp, templabel, delete=True):
+        """Assign a temporary drawnValue to the indexed array cell by
+        moving it into position on top of the array cell
+        Delete the temporary label if requested.
+        """
 
         toCellCoords = self.fillCoords(temp.val, self.cellCoords(index))
         toCellCenter = self.cellCenter(index)
@@ -128,9 +132,9 @@ class SortingBase(VisualizationApp):
         if delete:
             if templabel:
                 self.canvas.delete(templabel)
-            for item in self.list[index].items:
-                if item is not None:
-                    self.canvas.delete(item)
+        for item in self.list[index].items:
+            if item is not None:
+                self.canvas.delete(item)
         self.list[index] = temp
         
     def swap(self, a, b, aCellObjects=[], bCellObjects=[]):

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -316,6 +316,18 @@ def insert(self, item={val}):
         
         self.display(showNItems=self.nItems)
         self.cleanUp(callEnviron)
+    
+    def linearFill(self, increasing=True):
+        callEnviron = self.createCallEnvironment()        
+
+        self.list = [
+            drawnValue(
+                int((i if increasing else (self.size - 1 - i)) * self.valMax /
+                    (self.size - 1)))
+            for i in range(self.size)]
+        
+        self.display(showNItems=self.nItems)
+        self.cleanUp(callEnviron)
         
     getCode = """
 def get(self, n={n}):

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -159,6 +159,7 @@ class VisualizationApp(object):  # Base class for Python visualizations
         self.operationsUpper = LabelFrame(
             self.controlPanel, text="Operations", bg=self.DEFAULT_BG)
         self.operationsUpper.grid(row=0, column=0)
+        self.opButtons = []
         self.operationsPadding = Frame(
             self.operationsUpper, padx=2, pady=2, bg=self.OPERATIONS_BORDER)
         self.operationsPadding.pack(side=TOP)
@@ -287,6 +288,7 @@ class VisualizationApp(object):  # Base class for Python visualizations
             button.bind('<Enter>', self.makeArmHintHandler(button, helpText))
             button.bind('<Leave>', self.makeDisarmHandler(button))
             button.bind('<Button>', self.makeDisarmHandler(button), '+')
+        self.opButtons.append(button)
         return button
 
     def makeArgumentEntry(self, validationCmd):


### PR DESCRIPTION
This PR should close #187 by changing Shellsort to move the cells being insertion sorted (on each iteration of the outer loop) down to show they are the only ones being considered.  It also:

- Shows the code and highlights it
- Shows a span that indicates the `h` value
- Moves the span to align with the `outer` index 
- Shows the nShifts count
- Adds increasing and decreasing fill operations

The spacing of the array cells, local variable indices, and temporary variable is cramped.  That's partly due to the quicksort algorithm needing tall cells to better show the pivot lines.  Both Shellsort and quicksort appear in the same module and run on the same array.  There might be some better arrangements. 

Another slightly unsettling thing is that during the animation of the changes to the h value, the span shows intermediate spans using floating point numbers.  If the user pauses in the middle of that, the screenshot is rather inconsistent.  I don't think that's a big deal.  The only alternative I could think of would be to show the nearest integer value, but then we'd either have a non-smooth animation or text label that doesn't correspond to the length of the span.

Some of these changes, in particular the addition of the increasing and decreasing fill operations, affect other sorting visualizations via change to SortingBase.  That adds a few more files touched by this PR.