### PR TITLE
Issue188 Move temporary values in insertionsort

### DIFF
--- a/PythonVisualizations/AdvancedSorting.py
+++ b/PythonVisualizations/AdvancedSorting.py
@@ -427,10 +427,12 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
 
             if tempVal:
                 tempVal, _ = self.assignToTemp(
-                    outer, callEnviron, varName="temp", existing=label)
+                    outer, callEnviron, varName="temp", existing=label,
+                    tempCoords=self.tempLabelCoords(outer - 1))
             else:
                 tempVal, label = self.assignToTemp(
-                    outer, callEnviron, varName="temp")
+                    outer, callEnviron, varName="temp",
+                    tempCoords=self.tempLabelCoords(outer - 1))
                 callEnviron.add(label)
 
             # Inner loop starts at marked temporary item
@@ -453,8 +455,8 @@ def quicksort(self, lo={lo}, hi={hi}, short=3, key=identity):
                 centerX0 = self.cellCenter(inner)[0]
                 deltaX = centerX0 - self.canvas.coords(innerIndex[0])[0]
                 if deltaX != 0:
-                    self.moveItemsBy(
-                        innerIndex, (deltaX, 0), sleepTime=wait / 10) 
+                    self.moveItemsBy(innerIndex + tempVal.items + (label,),
+                                     (deltaX, 0), sleepTime=wait/5)
 
             # Delay to show discovery of insertion point for mark
             self.wait(wait)
@@ -567,7 +569,8 @@ def shellSort(self):
                 self.highlightCode('temp = self.get(outer)', callEnviron)
                 temp = self.list[outer]
                 tempVal, tempLabel = self.assignToTemp(
-                    outer, callEnviron, varName="temp", existing=tempLabel)
+                    outer, callEnviron, varName="temp", existing=tempLabel,
+                    tempCoords=self.tempLabelCoords(outer - h))
                 callEnviron |= set(tempVal.items + (tempLabel,))
 
                 # create the inner index
@@ -597,8 +600,16 @@ def shellSort(self):
                     self.highlightCode('inner -= h', callEnviron)
                     inner -= h
                     arrowPos = self.indexCoords(inner, level=-1)
-                    self.moveItemsTo(innerArrow, (arrowPos, arrowPos[:2]),
-                                     sleepTime=moveWait)
+                    tempLabelPos = self.tempLabelCoords(max(-1, inner - h))
+                    delta = subtract_vector(
+                        tempLabelPos, self.canvas.coords(tempLabel))
+                    tempCoords = [
+                        add_vector(self.canvas.coords(i), delta * 2)
+                        for i in tempVal.items] + [tempLabelPos]
+                    self.moveItemsTo(
+                        innerArrow + tempVal.items + (tempLabel,),
+                        [arrowPos, arrowPos[:2]] + tempCoords, 
+                        sleepTime=moveWait)
 
                     self.highlightCode('nShifts += 1', callEnviron, wait=wait)
                     nShifts += 1

--- a/PythonVisualizations/SimpleSorting.py
+++ b/PythonVisualizations/SimpleSorting.py
@@ -58,10 +58,12 @@ def insertionSort(self):
             temp = self.list[outer].val
             if tempVal:
                 tempVal, _ = self.assignToTemp(
-                    outer, callEnviron, varName="temp", existing=label)
+                    outer, callEnviron, varName="temp", existing=label,
+                    tempCoords=self.tempLabelCoords(outer - 1))
             else:
                 tempVal, label = self.assignToTemp(
-                    outer, callEnviron, varName="temp")
+                    outer, callEnviron, varName="temp",
+                    tempCoords=self.tempLabelCoords(outer - 1))
                 callEnviron.add(label)
 
             # Inner loop starts at marked temporary item
@@ -96,7 +98,8 @@ def insertionSort(self):
                 centerX0 = self.cellCenter(inner)[0]
                 deltaX = centerX0 - self.canvas.coords(innerIndex[0])[0]
                 if deltaX != 0:
-                    self.moveItemsBy(innerIndex, (deltaX, 0), sleepTime=wait/5)
+                    self.moveItemsBy(innerIndex + tempVal.items + (label,),
+                                     (deltaX, 0), sleepTime=wait/5)
                     
                 self.highlightCode('inner > 0', callEnviron, wait=wait)
                 if inner > 0:

--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -667,13 +667,15 @@ def traverse(self, function=print):
         return add_vector(cell_coords, self.arrayCellDelta())
 
     def currentCellCoords(self, index):
-        '''Compute coords from current position of array cell or based on
-        extreme left or rightmost cell'''
-        closest = max(0, min(len(self.arrayCells), index))
-        return add_vector(
-            subtract_vector(self.canvas.coords(self.arrayCells[closest]),
-                            self.arrayCellDelta()),
-            (self.CELL_WIDTH * (index - closest), 0) * 2)
+        '''Compute coords from current array cell position.  For indices
+        beyond ends of array, use the closest array cell and adjust by the
+        cell width horizontally.
+        '''
+        closest = max(0, min(len(self.arrayCells) - 1, index))
+        return subtract_vector(
+            add_vector(self.canvas.coords(self.arrayCells[closest]),
+                       ((index - closest) * self.CELL_WIDTH, 0) * 2),
+            self.arrayCellDelta())
 
     def currentCellCenter(self, index):
         x1, y1, x2, y2 = self.currentCellCoords(index)


### PR DESCRIPTION
This PR should close issue #188 by moving the temporary value along with the index seeking the insertion point in the insertion sort algorithms.  The insertion sort is introduced in SimpleSorting.py and shows up in both the Shellsort and quicksort animations.