### PR TITLE
Issue78 Add tree visualization to heap

### DIFF
--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -484,11 +484,12 @@ class BinaryTreeBase(VisualizationApp):
         if nodes is None:
             nodes = self.getAllDescendants(self.getRoot())
         self.restoreNodePositions(nodes, sleepTime=0)
-        for node in nodes:
-            key = node.getKey()
-            self.canvas.itemconfigure(node.drawnValue.items[2], text=str(key))
-            self.canvas.tag_raise(
-                node.drawnValue.items[2], node.drawnValue.items[1])
+        for node in nodes: # Restore text label above shape background
+            shape, text = node.drawnValue.items[1:3]
+            if self.canvas.type(text):
+                self.canvas.itemconfigure(text, text=str(node.getKey()))
+                if self.canvas.type(shape):
+                    self.canvas.tag_raise(text ,shape)
 
     def outputBoxSpacing(self, font=None):
         if font is None: font = self.VALUE_FONT

--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -330,16 +330,19 @@ class BinaryTreeBase(VisualizationApp):
         return V(parent.center) + V(
             -dx if childDirection == Child.LEFT else dx, self.LEVEL_GAP)
 
-    def nodeCenter(self, nodeIndex):
+    def nodeCenter(self, node):
         '''Calculate the coordinates for node based on its index in the nodes
-        array.  The index -1 indicates the binary tree object
+        array or from its center attribute, if a Node is passed.  The index -1
+        indicates the binary tree object.
         '''
-        if nodeIndex < 0:
+        if isinstance(node, Node):
+            return node.center
+        if node < 0:
             treeObjectBox = (
                 (0, 0, 40, 30) if getattr(self, 'treeObject', None) is None else
                 self.canvas.coords(self.treeObject[0]))
             return V(V(treeObjectBox[:2]) + V(treeObjectBox[2:])) / 2 
-        level, i = 0, nodeIndex
+        level, i = 0, node
         x, y = 0, 0
         while 0 < i:
             x = x / 2 + self.TREE_WIDTH / (4 if i % 2 == 0 else -4)
@@ -357,16 +360,12 @@ class BinaryTreeBase(VisualizationApp):
         that represent a node.  The node and parent parameters can be either
         a node, a node index, or a coordinate tuple for the center of the node.
         '''
-        if isinstance(node, Node):
-            nodeCenter = node.center
-        elif isinstance(node, int):
-            nodeCenter = self.getNode(node).center
+        if isinstance(node, (Node, int)):
+            nodeCenter = self.nodeCenter(node)
         elif isinstance(node, (tuple, list)):
             nodeCenter = node
-        if isinstance(parent, Node):
-            parentCenter = parent.center
-        elif isinstance(parent, int) and 0 <= parent:
-            parentCenter = self.getNode(parent).center
+        if isinstance(parent, Node) or isinstance(parent, int) and 0 <= parent:
+            parentCenter = self.nodeCenter(parent)
         elif isinstance(parent, (tuple, list)):
             parentCenter = parent
         else:

--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -531,7 +531,7 @@ class BinaryTreeBase(VisualizationApp):
    
     # create a Node object with key and parent specified
     # parent should be a Node object
-    def createNode(self, key, parent = None, direction = None):
+    def createNode(self, key, parent=None, direction=None, color=None):
         # calculate the node index
         nodeIndex = self.getChildIndex(parent, direction) if parent else 0
       
@@ -543,7 +543,8 @@ class BinaryTreeBase(VisualizationApp):
       
         # create the canvas items and the drawnValue object
         drawnValueObj = drawnValue(key, *self.createNodeShape(
-            *center, key, tag, parent=parent.center if parent else None))
+            *center, key, tag, parent=parent.center if parent else None,
+            color=color))
       
         # create the Node object
         node = Node(drawnValueObj, center, tag)

--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -494,7 +494,7 @@ class BinaryTreeBase(VisualizationApp):
             if self.canvas.type(text):
                 self.canvas.itemconfigure(text, text=str(node.getKey()))
                 if self.canvas.type(shape):
-                    self.canvas.tag_raise(text ,shape)
+                    self.canvas.tag_raise(text, shape)
 
     def outputBoxSpacing(self, font=None):
         if font is None: font = self.VALUE_FONT
@@ -691,10 +691,8 @@ class BinaryTreeBase(VisualizationApp):
     # remove the node's drawing and optionally its line
     def removeNodeDrawing(self, node, line=False):
         if isinstance(node, int): node = self.getNode(node)
-        self.canvas.delete(node.tag)
-        # should the line pointing to the node be removed?
-        if line: 
-            self.canvas.delete(node.getLine())
+        for item in node.drawnValue.items[0 if line else 1:]:
+            self.canvas.delete(item)
 
     # remove the node from the internal array (can be a node index)
     def removeNodeInternal(self, node):

--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -347,11 +347,12 @@ class BinaryTreeBase(VisualizationApp):
             i = (i - 1) // 2
         return self.ROOT_X0 + x, self.ROOT_Y0 + y
         
-    def nodeShapeCoordinates(self, center):
-        return (center[0] - self.CIRCLE_SIZE, center[1] - self.CIRCLE_SIZE,
-                center[0] + self.CIRCLE_SIZE, center[1] + self.CIRCLE_SIZE)
+    def nodeShapeCoordinates(self, center, radius=None):
+        if radius is None: radius = self.CIRCLE_SIZE
+        offset = V(radius, radius)
+        return (V(center) - offset) + (V(center) + offset)
 
-    def nodeItemCoords(self, node, parent=None):
+    def nodeItemCoords(self, node, parent=None, radius=None):
         '''Return coordinates for line to parent, shape, and text label items
         that represent a node.  The node and parent parameters can be either
         a node, a node index, or a coordinate tuple for the center of the node.
@@ -372,12 +373,15 @@ class BinaryTreeBase(VisualizationApp):
             parentCenter = nodeCenter
             
         return (nodeCenter + parentCenter, 
-                self.nodeShapeCoordinates(nodeCenter), nodeCenter)
+                self.nodeShapeCoordinates(nodeCenter, radius=radius),
+                nodeCenter)
 
-    def createNodeHighlight(self, node, highlightWidth=2, color=None):
+    def createNodeHighlight(
+            self, node, highlightWidth=2, color=None, radius=None):
         if color is None: color = self.FOUND_COLOR
         nCoords = self.nodeShapeCoordinates(
-            node.center if isinstance(node, Node) else self.nodeCenter(node))
+            node.center if isinstance(node, Node) else self.nodeCenter(node),
+            radius=radius)
         delta = (highlightWidth, highlightWidth)
         highlightCoords = (V(nCoords[:2]) - delta) + (V(nCoords[2:]) + delta)
         return self.canvas.create_oval(
@@ -429,18 +433,20 @@ class BinaryTreeBase(VisualizationApp):
         return text
 
     def createNodeShape(
-            self, x, y, key, tag, color=None, parent=None, lineColor='black',
-            lineWidth=1):
+            self, x, y, key, tag, color=None, parent=None, radius=None,
+            font=None, lineColor='black', lineWidth=1):
         '''Create canvas items for the circular node, its key label, and
         a line to the node centered at the parent coordinates. If parent
         is None, the line will be zero length to become invisible.
         Returns the line, circular background, and text label items
         '''
         if color is None: color = drawnValue.palette[2]
+        if radius is None: radius = self.CIRCLE_SIZE
+        if font is None: font = self.VALUE_FONT
         circle = self.canvas.create_circle(
-            x, y, self.CIRCLE_SIZE, tag = tag, fill=color, outline='')
+            x, y, radius, tag = tag, fill=color, outline='')
         circle_text = self.canvas.create_text(
-            x, y, text=key, font=self.VALUE_FONT, tag = tag)
+            x, y, text=key, font=font, tag=tag)
         line = self.canvas.create_line(
             x, y, *(parent if parent else (x, y)),
             tags = ("line", tag + "_line"), fill=lineColor, width=lineWidth)

--- a/PythonVisualizations/Heap.py
+++ b/PythonVisualizations/Heap.py
@@ -815,15 +815,15 @@ def remove(self):
                 itemsToMove, 
                 (cellCoords, cellCenter) + self.nodeItemCoords(0)[1:],
                 startAngle=startAngle, sleepTime=wait / 10)
-            for item in lastNode.drawnValue.items + (
-                    lastItem.items if lastItem is self.list[-1] else ()):
-                self.canvas.delete(item)
-            if lastItem is self.list[-1]:
-                self.list.pop()
             self.list[0] = drawnValue(lastItem.val, *itemsToMove[:2])
             rootNode.drawnValue.val = lastItem.val
             rootNode.drawnValue.items = (
                 rootNode.drawnValue.items[0],) + itemsToMove[2:]
+        for item in lastNode.drawnValue.items + (
+                lastItem.items if lastItem is self.list[-1] else ()):
+            self.canvas.delete(item)
+        if lastItem is self.list[-1]:
+            self.list.pop()
         
         self.highlightCode('self._siftDown(0)', callEnviron)
         self._siftDown(0)
@@ -900,6 +900,18 @@ def remove(self):
             self.canvas.tag_bind(item, '<Button>', handler)
 
         return cell_rect, cell_val
+    
+    def outputBoxCoords(self, font=None, padding=6, N=None):
+        '''Coordinates for an output box in lower right of canvas with enough
+        space to hold N values, defaulting to current heap size.  Normally
+        it is centered under the tree.'''
+        if N is None: N = len(self.list)
+        if font is None: font = self.VALUE_FONT
+        spacing = self.outputBoxSpacing(font)
+        canvasDims = self.widgetDimensions(self.canvas)
+        left = max(0, self.RECT[0] + self.RECT[2] - N * spacing - padding) // 2
+        return (left, canvasDims[1] - abs(font[1]) * 2 - padding,
+                left + N * spacing + padding, canvasDims[1] - padding)
         
     def display(self):
         self.canvas.delete("all")

--- a/PythonVisualizations/coordinates.py
+++ b/PythonVisualizations/coordinates.py
@@ -117,7 +117,7 @@ class vector(object):
         return (self.dot(vector(c, -s)), self.dot(vector(s, c)))
 
 def flat(*vectors): # Flatten a sequence of vectors into a tuple of coordinates
-    return tuple(v[i] for v in vectors for i in range(len(v)))
+    return tuple(elem for v in vectors for elem in v)
 
 def points(*coords, dimension=2): # Unflatten a list of coords into points of
     return [                      # a given dimension


### PR DESCRIPTION
This PR should resolve #78 by displaying both a binary tree alongside the array representation.  It can handle array contents before they are heapified, correctly tracking the heap condition when inserts and removals are being processed.  If the sifting isn't finished, only the root node is considered to meet the heap condition.

