### PR TITLE
Issue155 Fix user stop bugs in TowerOfHanoi

### DIFF
--- a/PythonVisualizations/TowerOfHanoi.py
+++ b/PythonVisualizations/TowerOfHanoi.py
@@ -42,7 +42,6 @@ class TowerOfHanoi(VisualizationApp):
         self.spindles = [[]] * 3      # lists of disk indices
         self.spindleBBoxes = [[]] * 3 # 4 coordinates of spindle's bounding box
         self.disks = []
-        self.picked = None
         self.moves = 0
         self.spindleWidth = max(4, self.width // 90)
         self.diskThickness = max(self.spindleWidth, 18)
@@ -177,6 +176,7 @@ def reset(self):
                     spindleLabel, self.spindleLabelCenter(spindle + 1),
                     sleepTime=wait / 5)
 
+        self.picked, self.pickedFrom = None, None
         if callEnviron:
             self.cleanUp(callEnviron2, sleepTime=wait / 5)
             self.highlightCode([], callEnviron, wait)
@@ -326,9 +326,8 @@ def reset(self):
                       self.spindles[spindle][-1], 'on top of it')
                 return
             if spindle is not None:
-                self.pickedFrom = spindle
                 self.spindles[spindle].pop()
-            self.picked = ID
+            self.picked, self.pickedFrom = ID, spindle
             self.lastPos = (event.x, event.y)
             self.canvas.tag_raise(tag, 'spindle')
             if spindle is not None:
@@ -352,7 +351,7 @@ def reset(self):
 
     def releaseHandler(self, ID, tag, normal, highlight):
         def relHandler(event):
-            if not self.operationMutex.locked():
+            if self.picked is None or not self.operationMutex.locked():
                 return
             diskBBox = self.canvas.bbox(tag)
             dropAt = None
@@ -380,6 +379,7 @@ def reset(self):
             if self.isDone():
                 self.showCompletion()
             self.operationMutex.release()
+            self.enableButtons()
         return relHandler
 
     def updateSpindles(self, *spindleIDs):

--- a/PythonVisualizations/TowerOfHanoi.py
+++ b/PythonVisualizations/TowerOfHanoi.py
@@ -43,7 +43,6 @@ class TowerOfHanoi(VisualizationApp):
         self.spindleBBoxes = [[]] * 3 # 4 coordinates of spindle's bounding box
         self.disks = []
         self.picked = None
-        self.allowUserMoves = True
         self.moves = 0
         self.spindleWidth = max(4, self.width // 90)
         self.diskThickness = max(self.spindleWidth, 18)
@@ -115,7 +114,6 @@ def reset(self):
         wait = 0.05
         callEnviron = None
         if nDisks > 0:
-            self.allowUserMoves = False
             callEnviron = self.createCallEnvironment(
                 code.format(**locals()), sleepTime=wait / 5, 
                 startAnimations=start)
@@ -183,7 +181,6 @@ def reset(self):
             self.cleanUp(callEnviron2, sleepTime=wait / 5)
             self.highlightCode([], callEnviron, wait)
             self.cleanUp(callEnviron, sleepTime=wait / 5)
-        self.allowUserMoves = True
 
     def createSpindleDrawing(self, index):
         tags = ('spindle', self.spindleTag(index))
@@ -311,15 +308,16 @@ def reset(self):
     
     def enterLeaveHandler(self, ID, tag, normal, highlight):
         def leaveEnterHandler(event):
-            kwargs = highlight if (event.type == EventType.Enter and
-                                   self.allowUserMoves and
-                                   self.isPickable(ID)) else normal
+            kwargs = highlight if (
+                event.type == EventType.Enter and self.isPickable(ID) and
+                not self.operationMutex.locked()) else normal
             self.canvas.itemconfigure(tag, **kwargs)
         return leaveEnterHandler
     
     def startMoveHandler(self, ID, tag, normal, highlight):
         def startHandler(event):
-            if not self.allowUserMoves:
+            if not self.operationMutex.acquire(blocking=False):
+                self.setMessage('Cannot move disks during other operation')
                 return
             self.cleanUp(ignoreStops=True)  # Clean up any items left by solver
             spindle, pos = self.diskSpindlePos(ID)
@@ -339,7 +337,7 @@ def reset(self):
 
     def moveHandler(self, ID, tag, normal, highlight):
         def mvHandler(event):
-            if self.picked is None or not self.allowUserMoves:
+            if self.picked is None or not self.operationMutex.locked():
                 return
             self.canvas.move(
                 tag, event.x - self.lastPos[0], event.y - self.lastPos[1])
@@ -354,7 +352,7 @@ def reset(self):
 
     def releaseHandler(self, ID, tag, normal, highlight):
         def relHandler(event):
-            if not self.allowUserMoves:
+            if not self.operationMutex.locked():
                 return
             diskBBox = self.canvas.bbox(tag)
             dropAt = None
@@ -366,16 +364,22 @@ def reset(self):
                     break
             if dropAt is None:
                 if self.pickedFrom is None:
+                    self.operationMutex.release()
                     return
                 dropAt = self.pickedFrom
             self.spindles[dropAt].append(ID)
             self.canvas.itemconfigure(self.spindleTag(dropAt), **normal)
-            self.restoreDisks()
+            diskItems = sorted(self.canvas.find_withtag(tag))
+            diskCoords = self.diskCoords(ID)
+            self.restoreTo(diskItems, diskCoords, after=lambda items, coords:
+                           [self.canvas.coords(i, c)
+                            for i, c in zip(items, coords)])
             self.canvas.tag_lower(tag, 'spindle')
             self.updateSpindles(dropAt)
             self.picked, self.pickedFrom = None, None
             if self.isDone():
                 self.showCompletion()
+            self.operationMutex.release()
         return relHandler
 
     def updateSpindles(self, *spindleIDs):
@@ -388,23 +392,15 @@ def reset(self):
                 self.spindleTag(spindle))
             self.window.update()
 
-    def restoreDisks(self, *diskIDs, cleanUpAll=True):
-        callEnviron = None if cleanUpAll else self.createCallEnvironment(
-            startAnimations=None)
-        self.startAnimations(enableStops=False)
-        for ID in (diskIDs if diskIDs else range(len(self.disks))):
-            tag = self.diskTag(ID)
-            items = sorted(self.canvas.find_withtag(tag))
-            current = [self.canvas.coords(item) for item in items
-                       if self.canvas.coords(item)]
-            target = self.diskCoords(ID)
-            if len(current) == len(target): # Both coords must be present
-                self.moveItemsTo(items, target, steps=10, sleepTime=0.01)
-        self.cleanUp(callEnviron)
-
     def stop(self, *args):   # Customize stop operation to restore disk
         super().stop(*args)
-        self.restoreDisks()
+
+        for ID in range(len(self.disks)):
+            diskItems = sorted(self.canvas.find_withtag(self.diskTag(ID)))
+            diskCoords = self.diskCoords(ID)
+            self.restoreTo(diskItems, diskCoords, after=lambda items, coords:
+                           [self.canvas.coords(i, c)
+                            for i, c in zip(items, coords)])
 
     def showCompletion(self):
         msg = 'Puzzle completed!'
@@ -417,7 +413,6 @@ def reset(self):
         targetCenter = V(canvasDimensions) * V(1/2, 1/2)
         targetSize = canvasDimensions[0] / 2
         targetAngle = -90
-        self.allowUserMoves = False
         callEnviron = self.createCallEnvironment(startAnimations=False)
         self.startAnimations(enableStops=False)
         starCoords = regularStar(starCenter, size, size * ratio, points, angle)
@@ -538,6 +533,32 @@ def solve(self, nDisks={nDisks}, start={start}, goal={goal}, spare={spare}):
                          sleepTime=wait)
         self.canvas.tag_lower(tag, 'spindle')
         self.updateSpindles(toSpindle)
+
+    def restoreTo(
+            self, items, targetCoords, by=0.2, dist2=4, wait=30,
+            increaseBy=1.1, after=None):
+        '''Restore a set of canvas items to their target coordinates.  At each
+        step, advance linearly by the given "by" factor until the
+        squared distance of all (non-deleted) items is less than dist2
+        from their target.  Increase the "by" factor by the increaseBy
+        ratio after waiting wait milliseconds between steps.  Execute
+        tha after function on the item and targetCoords at the end, if
+        callable.
+        '''
+        targets = [
+            (item, self.canvas_coords(item), tgt) 
+            for item, tgt in zip(items, targetCoords) if self.canvas.type(item)]
+        if all(distance2(target[1], target[2]) <= dist2 for target in targets):
+            if callable(after):
+                after(items, targetCoords)
+            return
+        by = max(0.01, min(1, by))
+        for item, coords, target in targets:
+            self.canvas.coords(
+                item, V(V(coords) * (1 - by)) + V(V(target) * by))
+        self.canvas.after(wait, lambda: self.restoreTo(
+            items, targetCoords, by * increaseBy, dist2, wait, increaseBy,
+            after))
         
     def makeButtons(self):
         vcmd = (self.window.register(numericValidate),
@@ -570,7 +591,7 @@ def solve(self, nDisks={nDisks}, start={start}, goal={goal}, spare={spare}):
     def cleanUp(self, callEnviron=None, **kwargs):
         super().cleanUp(callEnviron=callEnviron, **kwargs)
         if callEnviron is None and len(self.callStack) == 0:
-            self.allowUserMoves = True
+            self.setMessage('')
     
     # Button functions
     def clickNew(self):
@@ -591,9 +612,7 @@ def solve(self, nDisks={nDisks}, start={start}, goal={goal}, spare={spare}):
 
     def clickSolve(self):
         if self.leftSpindleFull():
-            self.allowUserMoves = False
             self.solve(self.nDisks(), startAnimations=self.startMode())
-            self.allowUserMoves = True
             self.setMessage('{} total move{} made'.format(
                 self.moves, '' if self.moves == 1 else 's'))
         else:

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -465,20 +465,20 @@ class VisualizationApp(Visualization): # Base class for visualization apps
                 b for b in (self.pauseButton, self.stepButton, self.stopButton)
                 if b]
             withArgs, withoutArgs = self.getOperations()
-            if mutex:
-                if not self.operationMutex.acquire(blocking=False):
-                    self.setMessage('Cannot run more than one operation')
-                    return
             try:
                 if cleanUpBefore:
                     self.cleanUp()
                 if button and button in animationControls:
                     button.focus_set()
+                if mutex:
+                    if not self.operationMutex.acquire(blocking=False):
+                        self.setMessage('Cannot run more than one operation')
+                        return
                 command()
             except UserStop as e:
                 self.cleanUp(self.callStack[0] if self.callStack else None,
                              ignoreStops=True)
-            if mutex:
+            if mutex and self.operationMutex.locked():
                 self.operationMutex.release()
             self.enableButtons()
             focus = self.window.focus_get()


### PR DESCRIPTION
This PR should close #155 by using the `operationMutex` to ensure only one operation runs at a time.  The way disks are returned to their spindles was changed to not use the animation method managed by the speed and pause/start/step control.  Many of the `UserStop` exceptions were happening when disk movements were being animated after the user dropped them where they weren't allowed to go.  If users attempt to pick up disks when the solver is running, they get a message that says only one operation can be run at a time.  In the rather unlikely case that a user picks up a disk with the mouse pointer and tries to launch New puzzle or Solve by pressing a key (Return/Enter for New, Space for Solve) before releasing the disk, it also provides the warning message about one operation at a time.

