### PR TITLE
Issue245 Weighted minimum spanning tree

### DIFF
--- a/PythonVisualizations/Graph.py
+++ b/PythonVisualizations/Graph.py
@@ -1187,16 +1187,15 @@ def degree(self, n={nVal}):
         self.highlightCode('self.validIndex(n)', callEnviron, wait=wait)
         self.highlightCode('inb, outb = 0, 0', callEnviron, wait=wait)
         inb, outb = 0, 0
-        inbCoords = self.vertexTable.cellCenter(self.nVertices() + 1)
-        outbCoords = self.vertexTable.cellCenter(self.nVertices() + 3)
+        Voffset = V(50, 0)
         outVars = [
             (self.canvas.create_text(
-                *(V(coords) - V(self.vertexTable.cellWidth // 2, 0)), anchor=E,
+                *(V(self.vertexTable.cellCenter(row)) + Voffset),
                 text=name, font=self.VARIABLE_FONT, fill=self.VARIABLE_COLOR),
              self.canvas.create_text(
-                 *coords, anchor=W, text='0', font=self.VARIABLE_FONT,
-                 fill=self.VARIABLE_COLOR))
-            for name, coords in zip(('inb', 'outb'), (inbCoords, outbCoords))]
+                 *(V(self.vertexTable.cellCenter(row + 1)) + Voffset),
+                 text='0', font=self.VARIABLE_FONT, fill=self.VARIABLE_COLOR))
+            for name, row in zip(('inb', 'outb'), (1, 4))]
         callEnviron |= set([var[0] for var in outVars])
         self.scrollToSee(flat(outVars), sleepTime=wait / 10)
             

--- a/PythonVisualizations/Graph.py
+++ b/PythonVisualizations/Graph.py
@@ -754,7 +754,7 @@ def minimumSpanningTree(self, n={nVal}):
         vMap = Table(
             self, (self.vertexTable.x0 + self.vertexTable.cellWidth + 5,
                    self.vertexTable.y0),
-            *[drawnValue(None) for k in range(self.nVertices())],
+            *([None] * self.nVertices()),
             label='vMap', labelAnchor=S, vertical=True, 
             labelFont=self.vertexTable.labelFont, 
             cellWidth=15, cellHeight=self.vertexTable.cellHeight, see=True,
@@ -803,7 +803,7 @@ def minimumSpanningTree(self, n={nVal}):
                                wait=wait)
             vMapArrow = self.createVMapArrow(vMap, len(treeVerts), vertex,
                                              see=True)
-            vMap[len(treeVerts)] = drawnValue(vertexLabel, *vMapArrow)
+            vMap[vertex] = drawnValue(len(treeVerts), *vMapArrow)
             callEnviron |= set(vMapArrow)
             localVars += vMapArrow
             faded += (Scrim.FADED_FILL,) * len(vMapArrow)

--- a/PythonVisualizations/Graph.py
+++ b/PythonVisualizations/Graph.py
@@ -810,7 +810,7 @@ def minimumSpanningTree(self, n={nVal}):
 
             self.highlightCode('tree.addVertex(self.getVertex(vertex))',
                                callEnviron, wait=wait)
-            vertCoords = self.canvas.coords(self.vertices[vertexLabel].items[1])
+            vertCoords = self.vertexCoords(vertexLabel)
             if len(treeVerts) == 0:
                 inflection = V(treeLabelAnchor) + V(300, 0)
                 tipCoords = self.labeledArrowCoords(
@@ -1063,7 +1063,7 @@ def sortVertsTopologically(
                                   self.vertices[vertexLabel].items[0])
             self.moveItemsTo(
                 dValue.items[1:] + vertexVertArrow,
-                (self.canvas.coords(self.vertices[vertexLabel].items[1]),
+                (self.vertexCoords(vertexLabel),
                  *self.labeledArrowCoords(vertexLabel, **vertexVertConfig)),
                 sleepTime=wait / 10, see=True, expand=True)
 

--- a/PythonVisualizations/Graph.py
+++ b/PythonVisualizations/Graph.py
@@ -1196,7 +1196,7 @@ def degree(self, n={nVal}):
                  *(V(self.vertexTable.cellCenter(row + 1)) + Voffset),
                  text='0', font=self.VARIABLE_FONT, fill=self.VARIABLE_COLOR))
             for name, row in zip(('inb', 'outb'), (1, 4))]
-        callEnviron |= set([var[0] for var in outVars])
+        callEnviron |= set(outVars[0] + outVars[1])
         self.scrollToSee(flat(outVars), sleepTime=wait / 10)
             
         self.highlightCode('j in self.vertices()', callEnviron, wait=wait)
@@ -1244,8 +1244,10 @@ def degree(self, n={nVal}):
             self.highlightCode('j in self.vertices()', callEnviron, wait=wait)
 
         self.highlightCode('return (inb, outb)', callEnviron)
+        result = tuple(var[1] for var in outVars)
+        callEnviron -= set(result)
         self.cleanUp(callEnviron)
-        return tuple(var[1] for var in outVars)
+        return result
     
     def enableButtons(self, enable=True):
         super().enableButtons(enable)

--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -257,6 +257,7 @@ class GraphBase(VisualizationApp):
             text='' if weight == 0 or not self.weighted else str(weight),
             font=self.VERTEX_FONT, fill=self.EDGE_COLOR, tags=tags + ('text',),
             activefill=self.ACTIVE_EDGE_COLOR)
+        self.canvas.tag_lower(line, 'vertex')
         if edgePair:
             self.canvas.tag_bind(line, '<Double-Button-1>', 
                                  self.deleteEdgeHandler(edgePair))

--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -127,13 +127,10 @@ class GraphBase(VisualizationApp):
             height = abs(self.CONTROLS_FONT[1])
         targetSize = (height, height)
         names = ('collapse', 'uncollapse')
-        images = dict((name, Img.open(name + '-symbol.png')) for name in names)
-        ratios = dict((name, min(*(V(targetSize) / V(images[name].size))))
-                      for name in names)
         self.adjMatControlImages = dict(
-            (name, ImageTk.PhotoImage(images[name].resize(
-                (int(round(d)) for d in V(images[name].size) * ratios[name]))))
+            (name, getPhotoImage(name + '-symbol.png', targetSize))
             for name in names)
+        return self.adjMatControlImages
             
     def toggleAdjacencyMatrixDisplay(self):
         if self.adjMatrixFrame in self.adjacencyMatrixPanel.pack_slaves():

--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -17,6 +17,7 @@ V = vector
 class GraphBase(VisualizationApp):
     MAX_VERTICES = 14
     VERTEX_RADIUS = 18
+    MAX_VERTEX_LABEL_WIDTH = 2
     vRadius = vector((VERTEX_RADIUS, VERTEX_RADIUS))
     VERTEX_FONT = ('Helvetica', -14)
     SELECTED_RADIUS = VERTEX_RADIUS * 6 // 5
@@ -41,6 +42,7 @@ class GraphBase(VisualizationApp):
     def __init__(                    # Create a graph visualization application
             self, title="Graph", graphRegion=None, weighted=False, **kwargs):
         kwargs['title'] = title
+        kwargs['maxArgWidth'] = self.MAX_VERTEX_LABEL_WIDTH
         if 'canvasBounds' not in kwargs:
             kwargs['canvasBounds'] = (0, 0, kwargs.get('canvasWidth', 800),
                                       kwargs.get('canvasHeight', 400))

--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -1001,11 +1001,12 @@ class GraphBase(VisualizationApp):
         for btn in (self.newVertexButton, self.randomFillButton):
             widgetState(
                 btn,
-                NORMAL if enable and self.nVertices() < self.MAX_VERTICES
-                else DISABLED)
+                NORMAL if enable and self.nVertices() < self.MAX_VERTICES and
+                self.getArgument(0) else DISABLED)
         widgetState(
             self.deleteVertexButton,
-            NORMAL if enable and self.nVertices() > 0 else DISABLED)
+            NORMAL if enable and self.nVertices() > 0 and
+            self.getArgument(0) else DISABLED)
     
     # Button functions
     def clickNewVertex(self):

--- a/PythonVisualizations/TableDisplay.py
+++ b/PythonVisualizations/TableDisplay.py
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
 
 V = vector
 
-def updateCells(func):  # Wrapper to update cells after changes to Table array
+def updateCells(func):  # Decorator to update cells after changes to Table array
     def fWrapper(self, *args, **kwargs):
         result = func(self, *args, **kwargs)
         self.drawCells()
@@ -207,6 +207,7 @@ class Table(list):     # Display a table (array/list) in a visualization app
     append = updateCells(list.append)
     extend = updateCells(list.extend)
     remove = updateCells(list.remove)
+    __setitem__ = updateCells(list.__setitem__)
 
     def __delitem__(self, key):
         result = super().__delitem__(key)

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -17,14 +17,6 @@ from tkinter import ttk
 PRESSED = 'pressed' # Oddly the ttk module does not define this like tk's ACTIVE
 
 try:
-    from PIL import Image as Img
-    from PIL import ImageTk
-except ModuleNotFoundError as e:
-    print('Pillow module not found.  Did you try running:')
-    print('pip3 install -r requirements.txt')
-    raise e
-
-try:
     from TextHighlight import *
     from tkUtilities import *
     from Visualization import *
@@ -82,6 +74,7 @@ class VisualizationApp(Visualization): # Base class for visualization apps
     SPEED_SCALE_MIN = 10
     SPEED_SCALE_MAX = 500
     SPEED_SCALE_DEFAULT = (SPEED_SCALE_MIN + SPEED_SCALE_MAX) // 2
+    DEBUG = False
 
     def __init__(  # Constructor
             self,
@@ -449,13 +442,10 @@ class VisualizationApp(Visualization): # Base class for visualization apps
             height = abs(self.CONTROLS_FONT[1])
         targetSize = (height, height)
         names = ('play', 'pause', 'skip-next', 'stop')
-        images = dict((name, Img.open(name + '-symbol.png')) for name in names)
-        ratios = dict((name, min(*(V(targetSize) / V(images[name].size))))
-                      for name in names)
         self.playControlImages = dict(
-            (name, ImageTk.PhotoImage(images[name].resize(
-                (int(round(d)) for d in V(images[name].size) * ratios[name]))))
+            (name, getPhotoImage(name + '-symbol.png', targetSize))
             for name in names)
+        return self.playControlImages
         
     def runOperation(self, command, cleanUpBefore, button=None, mutex=True):
         def animatedOperation(): # If button that uses arguments is provided,

--- a/PythonVisualizations/WeightedGraph.py
+++ b/PythonVisualizations/WeightedGraph.py
@@ -65,10 +65,12 @@ def minimumSpanningTree(self, n={nVal}):
             code=code.format(**locals()), startAnimations=start)
 
         nArrowConfig = {'level': 1, 'anchor': SE}
-        nArrow = self.vertexTable.createLabeledArrow(
-            n, 'n', see=True, **nArrowConfig)
-        callEnviron |= set(nArrow)
-        localVars, faded = nArrow, (Scrim.FADED_FILL,) * len(nArrow)
+        nVertConfig = {'level': 1, 'orientation': 10, 'anchor': SW}
+        nArrow = self.vertexTable.createLabeledArrow(n, 'n', **nArrowConfig)
+        nVertArrow = self.createLabeledArrow(nLabel, 'n', **nVertConfig)
+        callEnviron |= set(nArrow + nVertArrow)
+        localVars = nArrow + nVertArrow
+        faded = (Scrim.FADED_FILL,) * len(nArrow + nVertArrow)
         
         self.highlightCode('self.validIndex(n)', callEnviron, wait=wait)
         self.highlightCode('tree = WeightedGraph()', callEnviron, wait=wait)
@@ -96,6 +98,7 @@ def minimumSpanningTree(self, n={nVal}):
             fill=self.VARIABLE_COLOR, font=self.VARIABLE_FONT)
         callEnviron.add(nVertsLabel)
         localVars, faded = (*localVars, nVertsLabel), (*faded, Scrim.FADED_FILL)
+        nVertsBBox = self.canvas.bbox(nVertsLabel)
         
         self.highlightCode('vMap = [None] * nVerts', callEnviron, wait=wait)
         vMap = Table(
@@ -135,7 +138,7 @@ def minimumSpanningTree(self, n={nVal}):
         
         self.highlightCode('tree.addVertex(self.getVertex(n))', callEnviron,
                            wait=wait)
-        vertCoords = self.canvas.coords(self.vertices[nLabel].items[1])
+        vertCoords = self.vertexCoords(nLabel)
         inflection = V(treeLabelAnchor) + V(300, 0)
         tipCoords = self.labeledArrowCoords(
             nLabel,
@@ -153,8 +156,7 @@ def minimumSpanningTree(self, n={nVal}):
             *(V(vertCoords) - vRad), *(V(vertCoords) + vRad),
             fill='', outline=self.HIGHLIGHTED_VERTEX_COLOR,
             width=self.HIGHLIGHTED_VERTEX_WIDTH, tags=MSTtags)
-        self.canvas.tag_lower(treeVertHighlight,
-                              self.vertices[nLabel].items[0])
+        self.canvas.tag_lower(treeVertHighlight, 'vertex')
         copies = tuple(self.canvas.copyItem(item) 
                        for item in self.vertexTable[n].items)
         newItems = (treeVertHighlight, *copies)
@@ -176,6 +178,15 @@ def minimumSpanningTree(self, n={nVal}):
         vertexArrow, vertexArrowConfig = None, {}
         vertexVertArrow = None
         vertexVertConfig = {'orientation': 30, 'anchor': SW}
+        edgeLabel, wLabel = None, None
+        highlightedEdge = self.canvas.create_line(
+            *vertCoords, *vertCoords, tags=MSTtags,
+            fill=self.ACTIVE_EDGE_COLOR, width=self.HIGHLIGHTED_EDGE_WIDTH)
+        self.canvas.tag_lower(highlightedEdge, 'edge')
+        callEnviron.add(highlightedEdge)
+        localVars, faded = (*localVars, highlightedEdge), (
+            *faded, Scrim.FADED_FILL)
+
         self.highlightCode('tree.nVertices() < nVerts', callEnviron, wait=wait)
         while len(treeVerts) < nVerts:
             self.highlightCode('vertex in self.adjacentVertices(n)',
@@ -212,16 +223,20 @@ def minimumSpanningTree(self, n={nVal}):
                     vertLabels = tuple(
                         self.canvas.copyItem(self.vertices[v].items[1])
                         for v in edge)
+                    for j in (0, 1):
+                        self.canvas.itemConfig(
+                            vertLabels[j],
+                            text=(' {}' if j else '{} ').format(
+                                self.canvas.itemConfig(vertLabels[j], 'text')),
+                            anchor=W if j else E)
                     weightLabel = self.canvas.create_text(
                         *self.canvas.coords(self.edges[edge].items[1]),
                         text=str(weight), font=self.VERTEX_FONT)
                     toMove = (*vertLabels, weightLabel)
                     callEnviron |= set(toMove)
                     insertAt = self.edgeInsertPosition(edges, w)
-                    dx, dy = 10, textHeight(self.ADJACENCY_MATRIX_FONT) // 2
-                    Vcenter = V(edges.cellCenter(insertAt))
-                    newCoords=(Vcenter + V(-dx, -dy), Vcenter + V(dx, -dy),
-                               Vcenter + V(0, dy))
+                    PQcoords = self.edgePriorityQueueCoords(edges, insertAt)
+                    newCoords=(PQcoords[1], PQcoords[1], PQcoords[2])
                     toMove += flat(*(ed.items for ed in edges[insertAt:]))
                     newCoords += flat(*[
                         self.edgePriorityQueueCoords(edges, j)
@@ -231,9 +246,10 @@ def minimumSpanningTree(self, n={nVal}):
                     edges[insertAt:insertAt] = [
                         self.createEdgePriorityQueueEntry(
                             edges, edge, w, insertAt)]
-                    callEnviron |= set(edges[insertAt].items)
+                    newItems = (edges.items()[-1], *edges[insertAt].items)
+                    callEnviron |= set(newItems)
                     self.dispose(callEnviron, *toMove[:3])
-                    localVars += (edges.items()[-1], *edges[insertAt].items)
+                    localVars += newItems
                     faded += (
                         Scrim.FADED_OUTLINE,
                         *((Scrim.FADED_FILL,) * len(edges[insertAt].items)))
@@ -242,45 +258,91 @@ def minimumSpanningTree(self, n={nVal}):
                                    callEnviron, wait=wait)
                 colors = self.canvas.fadeItems(localVars, faded)
                 
+            self.canvas.restoreItems(localVars, colors, top=False)
             self.highlightCode('edges.isEmpty()', callEnviron, wait=wait)
             self.highlightCode(
                 ('edge, w = (',
                  '(None, 0)' if len(edges) == 0 else 'edges.remove()'),
                 callEnviron, wait=wait)
+            dValue = None if len(edges) == 0 else edges.pop(0)
+            edge, w = (None, 0) if dValue is None else dValue.val
+            edgeLabelCoords = (
+                (nVertsBBox[0], nVertsBBox[3] + 5) if edge is None else
+                self.edgeCoords(
+                    *(self.canvas.coords(self.vertices[edge[j]].items[1])
+                      for j in (0, 1)))[-1])
+            edgeLabelAnchor = NE if edge is None else CENTER
+            if edgeLabel is None:
+                wLabel = self.canvas.create_text(
+                    nVertsBBox[2], nVertsBBox[3] + 5, anchor=NE,
+                    text='w = {}'.format(w), font=self.VARIABLE_FONT,
+                    fill=self.VARIABLE_COLOR)
+                edgeLabel = self.canvas.create_text(
+                    *edgeLabelCoords, anchor=edgeLabelAnchor, text='edge',
+                    font=self.VARIABLE_FONT, fill=self.VARIABLE_COLOR)
+                callEnviron |= set((wLabel, edgeLabel))
+                localVars += (wLabel, edgeLabel)
+                faded += (Scrim.FADED_FILL,) * 2
+            self.updateEdgeAndWeightFromQueue(
+                edge, w, edgeLabel, wLabel, highlightedEdge, edges, dValue,
+                callEnviron, wait, edgeLabelCoords, edgeLabelAnchor)
+                    
+            self.highlightCode('not edges.isEmpty()', callEnviron, wait=wait)
+            if len(edges) > 0:
+                self.highlightCode('vMap[edge[1]] is not None', callEnviron,
+                                   wait=wait)
+            while (len(edges) > 0 and
+                   vMap[self.getVertexIndex(edge[1])] is not None):
+                self.highlightCode('edge, w = edges.remove()', callEnviron,
+                                   wait=wait)
+                
+                dValue = edges.pop(0)
+                edge, w = dValue.val
+                self.updateEdgeAndWeightFromQueue(
+                    edge, w, edgeLabel, wLabel, highligtedEdge, edges, dValue,
+                    callEnviron, wait)
 
-            vMapArrow = self.createVMapArrow(vMap, len(treeVerts), vertex,
-                                             see=True)
-            vMap[vertex] = drawnValue(len(treeVerts), *vMapArrow)
+                self.highlightCode('not edges.isEmpty() TBD', callEnviron,
+                                   wait=wait)
+                if len(edges) > 0:
+                    self.highlightCode('vMap[edge[1]] is not None', callEnviron,
+                                       wait=wait)
+                
+            self.highlightCode('edge is None', callEnviron, wait=wait)
+            if edge is not None:
+                self.highlightCode(('vMap[edge[1]] is not None', 2),
+                                   callEnviron, wait=wait)
+            if edge is None or vMap[self.getVertexIndex(edge[1])] is not None:
+                self.highlightCode('break', callEnviron, wait=wait)
+                break
+                
+            self.highlightCode('n = edge[1]', callEnviron, wait=wait)
+            nLabel = edge[1]
+            n = self.getVertexIndex(nLabel)
+            self.moveItemsTo(
+                nArrow + nVertArrow,
+                self.vertexTable.labeledArrowCoords(n, **nArrowConfig) +
+                self.labeledArrowCoords(nLabel, **nVertConfig),
+                sleepTime=wait / 10)
+
+            self.highlightCode('vMap[n] = tree.nVertices()', callEnviron,
+                               wait=wait)
+            vMapArrow = self.createVMapArrow(vMap, len(treeVerts), n)
+            vMap[n] = drawnValue(len(treeVerts), *vMapArrow)
             callEnviron |= set(vMapArrow)
             localVars += vMapArrow
             faded += (Scrim.FADED_FILL,) * len(vMapArrow)
 
-            self.highlightCode('tree.addVertex(self.getVertex(vertex))',
+            self.highlightCode(('tree.addVertex(self.getVertex(n))', 2),
                                callEnviron, wait=wait)
-            vertCoords = self.canvas.coords(self.vertices[vertexLabel].items[1])
-            if len(treeVerts) == 0:
-                inflection = V(treeLabelAnchor) + V(300, 0)
-                tipCoords = self.labeledArrowCoords(
-                    vertexLabel,
-                    orientation=V(V(inflection) - V(vertCoords)).orient2d() +
-                    90)[0][2:]
-                treeArrow = self.canvas.create_line(
-                    *treeLabelAnchor, *inflection, *tipCoords,
-                    arrow=LAST, fill=self.HIGHLIGHTED_EDGE_COLOR, smooth=True,
-                    splinesteps=abs(int(tipCoords[1] - treeLabelAnchor[1])))
-                callEnviron.add(treeArrow)
-                localVars, faded = (*localVars, treeArrow), (
-                    *faded, Scrim.FADED_FILL)
-
-            vRad = V((self.HIGHLIGHTED_VERTEX_RADIUS, ) * 2)
+            vertCoords = self.vertexCoords(nLabel)
             treeVertHighlight = self.canvas.create_oval(
                 *(V(vertCoords) - vRad), *(V(vertCoords) + vRad),
                 fill='', outline=self.HIGHLIGHTED_VERTEX_COLOR,
                 width=self.HIGHLIGHTED_VERTEX_WIDTH, tags=MSTtags)
-            self.canvas.tag_lower(treeVertHighlight,
-                                  self.vertices[vertexLabel].items[0])
+            self.canvas.tag_lower(treeVertHighlight, 'vertex')
             copies = tuple(self.canvas.copyItem(item) 
-                           for item in self.vertexTable[vertex].items)
+                           for item in self.vertexTable[n].items)
             newItems = (treeVertHighlight, *copies)
             callEnviron |= set(newItems)
             localVars, faded = localVars + newItems, faded + (
@@ -297,27 +359,25 @@ def minimumSpanningTree(self, n={nVal}):
             localVars, faded = (*localVars, treeVerts.items()[-1]), (
                 *faded, Scrim.FADED_OUTLINE)
             
-            self.highlightCode('len(path) > 1', callEnviron, wait=wait)
-            if len(path) > 1:
-                self.highlightCode(
-                    'tree.addEdge(vMap[path[-2]], vMap[path[-1]])', callEnviron,
-                    wait=wait)
-                coords = self.canvas.coords(edgesInPath[-1])
-                delta = V(coords[:2]) - V(coords[-2:])
-                treeEdgeHighlight = self.canvas.create_line(
-                    *coords, smooth=True, tags=MSTtags,
-                    splinesteps=int(max(abs(delta[0]), abs(delta[1]), 5)),
-                    fill=self.HIGHLIGHTED_EDGE_COLOR,
-                    width=self.HIGHLIGHTED_EDGE_WIDTH)
-                self.canvas.lower(treeEdgeHighlight, edgesInPath[-1])
-                callEnviron.add(treeEdgeHighlight)
-                localVars, faded = (*localVars, treeEdgeHighlight), (
-                    *faded, Scrim.FADED_FILL)
-                treeEdges.append(drawnValue(edgesInPath[-1], treeEdgeHighlight))
+            self.highlightCode(
+                'tree.addEdge(vMap[edge[0]], vMap[edge[1]], w)', callEnviron,
+                wait=wait)
+            coords = self.canvas.coords(self.edges[edge].items[0])
+            delta = V(coords[:2]) - V(coords[-2:])
+            treeEdgeHighlight = self.canvas.create_line(
+                *coords, smooth=True, tags=MSTtags,
+                splinesteps=int(max(abs(delta[0]), abs(delta[1]), 5)),
+                fill=self.HIGHLIGHTED_EDGE_COLOR,
+                width=self.HIGHLIGHTED_EDGE_WIDTH)
+            self.canvas.lower(treeEdgeHighlight, 'edge')
+            callEnviron.add(treeEdgeHighlight)
+            localVars, faded = (*localVars, treeEdgeHighlight), (
+                *faded, Scrim.FADED_FILL)
+            treeEdges.append(
+                drawnValue(self.edges[edge].items[0], treeEdgeHighlight))
                 
-            colors = self.canvas.fadeItems(localVars, faded)
-            
-        self.canvas.restoreItems(localVars, colors, top=False)
+            self.highlightCode('tree.nVertices() < nVerts', callEnviron,
+                               wait=wait)
             
         self.highlightCode('return tree', callEnviron, wait=wait)
         self.cleanUp(callEnviron)
@@ -350,7 +410,45 @@ def minimumSpanningTree(self, n={nVal}):
         text2 = self.canvas.create_text(
             *coords[2], text=str(weight), font=self.ADJACENCY_MATRIX_FONT)
         return drawnValue((edge, weight), rect, text1, text2)
-        
+
+    def updateEdgeAndWeightFromQueue(
+            self, edge, weight, edgeLabel, weightLabel, highlightedEdge, edges,
+            dValue, callEnviron, wait, edgeLabelCoords=None,
+            edgeLabelAnchor=None):
+        if edgeLabelCoords is None:
+            edgeLabelCoords = (
+                (nVertsBBox[0], nVertsBBox[3] + 5) if edge is None else
+                self.edgeCoords(
+                    *(self.canvas.coords(self.vertices[edge[j]].items[1])
+                      for j in (0, 1)))[-1])
+        if edgeLabelAnchor is None:
+            edgeLabelAnchor = NE if edge is None else CENTER
+        self.canvas.changeAnchor(edgeLabelAnchor, edgeLabel)
+        toMove = [edgeLabel]
+        moveTo = [edgeLabelCoords]
+        if edge is not None:
+            queueFrontCoords = self.edgePriorityQueueCoords(edges, 0)
+            toMove += [self.canvas.create_text(
+                *queueFrontCoords[1], text=(' {}' if i else '{} ').format(v),
+                anchor=W if i else E, font=self.ADJACENCY_MATRIX_FONT)
+                       for i, v in enumerate(edge)]
+            moveTo += [self.vertexCoords(v) for v in edge]
+            callEnviron |= set(toMove[-2:])
+            self.dispose(callEnviron, *dValue.items[:2])
+            toMove.append(dValue.items[2])
+            moveTo.append(self.canvas.coords(weightLabel))
+            toDispose = toMove[1:]
+            toMove += list(flat(*(dv.items for dv in edges)))
+            moveTo += list(flat(*(self.edgePriorityQueueCoords(edges, j)
+                                  for j in range(len(edges)))))
+        self.moveItemsLinearly(toMove, moveTo, sleepTime=wait / 10)
+        self.canvas.coords(
+            highlightedEdge,
+            self.canvas.coords(highlightedEdge)[:2] * 2 if edge is None else
+            self.vertexCoords(edge[0]) + self.vertexCoords(edge[1]))
+        self.canvas.itemConfig(weightLabel, text='w = {}'.format(weight))
+        self.dispose(callEnviron, *toDispose)
+    
     def enableButtons(self, enable=True):
         super(type(self).__bases__[0], self).enableButtons( # Grandparent
             enable)

--- a/PythonVisualizations/WeightedGraph.py
+++ b/PythonVisualizations/WeightedGraph.py
@@ -17,6 +17,32 @@ class WeightedGraph(Graph):
         super().__init__(title=title, weighted=True)
         
     minimumSpanningTreeCode = '''
+def minimumSpanningTree(self, n={nVal}):
+   self.validIndex(n)
+   tree = WeightedGraph()
+   nVerts = self.nVertices()
+   vMap = [None] * nVerts
+   edges = Heap(key=weight, descending=False)
+   vMap[n] = 0
+   tree.addVertex(self.getVertex(n))
+   while tree.nVertices() < nVerts:
+      for vertex in self.adjacentVertices(n):
+         if vMap[vertex] is None:
+            edges.insert(
+               ((n, vertex), self.edgeWeight(n, vertex)))
+      edge, w = (
+         (None, 0) if edges.isEmpty() else edges.remove())
+      while (not edges.isEmpty() and
+             vMap[edge[1]] is not None):
+         edge, w = edges.remove()
+      if (edge is None or
+          vMap[edge[1]] is not None):
+         break
+      n = edge[1]
+      vMap[n] = tree.nVertices()
+      tree.addVertex(self.getVertex(n))
+      tree.addEdge(vMap[edge[0]], vMap[edge[1]], w)
+   return tree
 '''
 
     def minimumSpanningTree(
@@ -35,11 +61,155 @@ class WeightedGraph(Graph):
             n, 'n', see=True, **nArrowConfig)
         callEnviron |= set(nArrow)
         localVars, faded = nArrow, (Scrim.FADED_FILL,) * len(nArrow)
+        
+        self.highlightCode('self.validIndex(n)', callEnviron, wait=wait)
+        self.highlightCode('tree = WeightedGraph()', callEnviron, wait=wait)
+        treeLabelAnchor = (70, self.graphRegion[3] + 60)
+        treeLabel = self.canvas.create_text(
+            *treeLabelAnchor, text='tree', anchor=E,
+            fill=self.VARIABLE_COLOR, font=self.VARIABLE_FONT)
+        callEnviron.add(treeLabel)
+        localVars, faded = (*localVars, treeLabel), (*faded, Scrim.FADED_FILL)
+        treeVerts = Table(
+            self, V(treeLabelAnchor) + V(5, 15), vertical=False,
+            label='vertices', cellHeight=self.VERTEX_RADIUS,
+            labelFont=(self.VARIABLE_FONT[0], -12), see=True,
+            cellWidth=self.VERTEX_RADIUS * 3 // 2, cellBorderWidth=1)
+        localVars += treeVerts.items()
+        callEnviron |= set(treeVerts.items())
+        faded += (Scrim.FADED_FILL,) * len(treeVerts.items())
+        treeEdges = []
+        
+        self.highlightCode('vMap = [None] * self.nVertices()', callEnviron,
+                           wait=wait)
+        vMap = Table(
+            self, (self.vertexTable.x0 + self.vertexTable.cellWidth + 5,
+                   self.vertexTable.y0),
+            *[drawnValue(None) for k in range(self.nVertices())],
+            label='vMap', labelAnchor=S, vertical=True, 
+            labelFont=self.vertexTable.labelFont, 
+            cellWidth=15, cellHeight=self.vertexTable.cellHeight, see=True,
+            cellBorderWidth=self.vertexTable.cellBorderWidth,
+            indicesFont=self.vertexTable.labelFont, indicesAnchor=W,
+            indicesOffset=30)
+        callEnviron |= set(vMap.items())
+        localVars += vMap.items()
+        faded += (Scrim.FADED_FILL,
+                 *((Scrim.FADED_OUTLINE,) * (len(vMap.items()) - 1)))
+        
+        vertexArrow, vertexArrowConfig = None, {}
+        vertexVertArrow = None
+        vertexVertConfig = {'orientation': 30, 'anchor': SW}
+        self.highlightCode('vertex, path in self.depthFirst(n)', callEnviron,
+                           wait=wait)
+        colors = self.canvas.fadeItems(localVars, faded)
+        for vertex, path in self.depthFirst(n):
+            self.canvas.restoreItems(localVars, colors, top=False)
+            vertexLabel = self.vertexTable[vertex].val
+            edgesInPath = [
+                self.edges[path[v].val, path[v + 1].val].items[0]
+                for v in range(len(path) - 1)]
+            if vertexArrow is None:
+                vertexArrow = self.vertexTable.createLabeledArrow(
+                    vertex, 'vertex', see=True, **vertexArrowConfig)
+                vertexVertArrow = self.createLabeledArrow(
+                    vertexLabel, 'vertex', see=True, **vertexVertConfig)
+                arrows = vertexArrow + vertexVertArrow
+                callEnviron |= set(arrows)
+                localVars += arrows
+                faded += (Scrim.FADED_FILL,) * len(arrows)
+            else:
+                self.moveItemsTo(
+                    vertexArrow + vertexVertArrow, 
+                    self.vertexTable.labeledArrowCoords(
+                        vertex, **vertexArrowConfig) +
+                    self.labeledArrowCoords(vertexLabel, **vertexVertConfig),
+                    sleepTime=wait / 10, see=True, expand=True)
+            for edge in edgesInPath:
+                self.canvas.itemconfigure(
+                    edge, width=self.ACTIVE_EDGE_WIDTH,
+                    fill=self.ACTIVE_EDGE_COLOR)
 
-        self.setMessage('MST TBD')
+            self.highlightCode('vMap[vertex] = tree.nVertices()', callEnviron,
+                               wait=wait)
+            vMapArrow = self.createVMapArrow(vMap, len(treeVerts), vertex,
+                                             see=True)
+            vMap[len(treeVerts)] = drawnValue(vertexLabel, *vMapArrow)
+            callEnviron |= set(vMapArrow)
+            localVars += vMapArrow
+            faded += (Scrim.FADED_FILL,) * len(vMapArrow)
+
+            self.highlightCode('tree.addVertex(self.getVertex(vertex))',
+                               callEnviron, wait=wait)
+            vertCoords = self.canvas.coords(self.vertices[vertexLabel].items[1])
+            if len(treeVerts) == 0:
+                inflection = V(treeLabelAnchor) + V(300, 0)
+                tipCoords = self.labeledArrowCoords(
+                    vertexLabel,
+                    orientation=V(V(inflection) - V(vertCoords)).orient2d() +
+                    90)[0][2:]
+                treeArrow = self.canvas.create_line(
+                    *treeLabelAnchor, *inflection, *tipCoords,
+                    arrow=LAST, fill=self.HIGHLIGHTED_EDGE_COLOR, smooth=True,
+                    splinesteps=abs(int(tipCoords[1] - treeLabelAnchor[1])))
+                callEnviron.add(treeArrow)
+                localVars, faded = (*localVars, treeArrow), (
+                    *faded, Scrim.FADED_FILL)
+
+            vRad = V((self.HIGHLIGHTED_VERTEX_RADIUS, ) * 2)
+            treeVertHighlight = self.canvas.create_oval(
+                *(V(vertCoords) - vRad), *(V(vertCoords) + vRad),
+                fill='', outline=self.HIGHLIGHTED_VERTEX_COLOR,
+                width=self.HIGHLIGHTED_VERTEX_WIDTH, tags=MSTtags)
+            self.canvas.tag_lower(treeVertHighlight,
+                                  self.vertices[vertexLabel].items[0])
+            copies = tuple(self.canvas.copyItem(item) 
+                           for item in self.vertexTable[vertex].items)
+            newItems = (treeVertHighlight, *copies)
+            callEnviron |= set(newItems)
+            localVars, faded = localVars + newItems, faded + (
+                Scrim.FADED_FILL,) * len(newItems)
+            self.moveItemsLinearly(
+                copies, (treeVerts.cellCoords(len(treeVerts)),
+                         treeVerts.cellCenter(len(treeVerts))),
+                startFont=self.canvas.getItemFont(copies[1]),
+                endFont=self.ADJACENCY_MATRIX_FONT, sleepTime=wait / 10,
+                see=True, expand=True)
             
+            treeVerts.append(drawnValue(vertexLabel, newItems))
+            callEnviron.add(treeVerts.items()[-1])
+            localVars, faded = (*localVars, treeVerts.items()[-1]), (
+                *faded, Scrim.FADED_OUTLINE)
+            
+            self.highlightCode('len(path) > 1', callEnviron, wait=wait)
+            if len(path) > 1:
+                self.highlightCode(
+                    'tree.addEdge(vMap[path[-2]], vMap[path[-1]])', callEnviron,
+                    wait=wait)
+                coords = self.canvas.coords(edgesInPath[-1])
+                delta = V(coords[:2]) - V(coords[-2:])
+                treeEdgeHighlight = self.canvas.create_line(
+                    *coords, smooth=True, tags=MSTtags,
+                    splinesteps=int(max(abs(delta[0]), abs(delta[1]), 5)),
+                    fill=self.HIGHLIGHTED_EDGE_COLOR,
+                    width=self.HIGHLIGHTED_EDGE_WIDTH)
+                self.canvas.lower(treeEdgeHighlight, edgesInPath[-1])
+                callEnviron.add(treeEdgeHighlight)
+                localVars, faded = (*localVars, treeEdgeHighlight), (
+                    *faded, Scrim.FADED_FILL)
+                treeEdges.append(drawnValue(edgesInPath[-1], treeEdgeHighlight))
+                
+            self.highlightCode(
+                'vertex, path in self.depthFirst(n)', callEnviron, wait=wait)
+            for edge in edgesInPath:
+                self.canvas.itemConfig(
+                    edge, width=self.EDGE_WIDTH, fill=self.EDGE_COLOR)
+            colors = self.canvas.fadeItems(localVars, faded)
+            
+        self.canvas.restoreItems(localVars, colors, top=False)
+            
+        self.highlightCode('return tree', callEnviron, wait=wait)
         self.cleanUp(callEnviron)
-
     
     def enableButtons(self, enable=True):
         super(type(self).__bases__[0], self).enableButtons( # Grandparent

--- a/PythonVisualizations/WeightedGraph.py
+++ b/PythonVisualizations/WeightedGraph.py
@@ -231,7 +231,7 @@ def minimumSpanningTree(self, n={nVal}):
                             anchor=W if j else E)
                     weightLabel = self.canvas.create_text(
                         *self.canvas.coords(self.edges[edge].items[1]),
-                        text=str(weight), font=self.VERTEX_FONT)
+                        text=str(w), font=self.VERTEX_FONT)
                     toMove = (*vertLabels, weightLabel)
                     callEnviron |= set(toMove)
                     insertAt = self.edgeInsertPosition(edges, w)
@@ -266,11 +266,7 @@ def minimumSpanningTree(self, n={nVal}):
                 callEnviron, wait=wait)
             dValue = None if len(edges) == 0 else edges.pop(0)
             edge, w = (None, 0) if dValue is None else dValue.val
-            edgeLabelCoords = (
-                (nVertsBBox[0], nVertsBBox[3] + 5) if edge is None else
-                self.edgeCoords(
-                    *(self.canvas.coords(self.vertices[edge[j]].items[1])
-                      for j in (0, 1)))[-1])
+            edgeLabelCoords = self.edgeLabelCoords(edge, nVertsBBox)
             edgeLabelAnchor = NE if edge is None else CENTER
             if edgeLabel is None:
                 wLabel = self.canvas.create_text(
@@ -285,7 +281,7 @@ def minimumSpanningTree(self, n={nVal}):
                 faded += (Scrim.FADED_FILL,) * 2
             self.updateEdgeAndWeightFromQueue(
                 edge, w, edgeLabel, wLabel, highlightedEdge, edges, dValue,
-                callEnviron, wait, edgeLabelCoords, edgeLabelAnchor)
+                nVertsBBox, callEnviron, wait, edgeLabelCoords, edgeLabelAnchor)
                     
             self.highlightCode('not edges.isEmpty()', callEnviron, wait=wait)
             if len(edges) > 0:
@@ -300,7 +296,7 @@ def minimumSpanningTree(self, n={nVal}):
                 edge, w = dValue.val
                 self.updateEdgeAndWeightFromQueue(
                     edge, w, edgeLabel, wLabel, highligtedEdge, edges, dValue,
-                    callEnviron, wait)
+                    nVertsBBox, callEnviron, wait)
 
                 self.highlightCode('not edges.isEmpty() TBD', callEnviron,
                                    wait=wait)
@@ -413,19 +409,16 @@ def minimumSpanningTree(self, n={nVal}):
 
     def updateEdgeAndWeightFromQueue(
             self, edge, weight, edgeLabel, weightLabel, highlightedEdge, edges,
-            dValue, callEnviron, wait, edgeLabelCoords=None,
+            dValue, nVertsBBox, callEnviron, wait, edgeLabelCoords=None,
             edgeLabelAnchor=None):
         if edgeLabelCoords is None:
-            edgeLabelCoords = (
-                (nVertsBBox[0], nVertsBBox[3] + 5) if edge is None else
-                self.edgeCoords(
-                    *(self.canvas.coords(self.vertices[edge[j]].items[1])
-                      for j in (0, 1)))[-1])
+            edgeLabelCoords = self.edgeLabelCoords(edge, nVertsBBox)
         if edgeLabelAnchor is None:
             edgeLabelAnchor = NE if edge is None else CENTER
         self.canvas.changeAnchor(edgeLabelAnchor, edgeLabel)
         toMove = [edgeLabel]
         moveTo = [edgeLabelCoords]
+        toDispose = []
         if edge is not None:
             queueFrontCoords = self.edgePriorityQueueCoords(edges, 0)
             toMove += [self.canvas.create_text(
@@ -448,6 +441,13 @@ def minimumSpanningTree(self, n={nVal}):
             self.vertexCoords(edge[0]) + self.vertexCoords(edge[1]))
         self.canvas.itemConfig(weightLabel, text='w = {}'.format(weight))
         self.dispose(callEnviron, *toDispose)
+
+    def edgeLabelCoords(self, edge, nVertsBBox):
+        return ((nVertsBBox[0], nVertsBBox[3] + 5) if edge is None else
+                self.edgeCoords(
+                    *(self.vertexCoords(edge[j])
+                      for j in ((1, 0) if edge == self.edges[edge].val else
+                                (0, 1))))[-1])
     
     def enableButtons(self, enable=True):
         super(type(self).__bases__[0], self).enableButtons( # Grandparent

--- a/PythonVisualizations/coordinates.py
+++ b/PythonVisualizations/coordinates.py
@@ -127,6 +127,18 @@ class vector(object):
         'Get normal vector of a 2-D vector'
         return - self.coords[1], self.coords[0]
 
+def collinear(p1, p2, p3, threshold=1e-8):
+    'Test if three points are collinear'
+    d1, d2 = vector(vector(p2) - vector(p1)), vector(vector(p3) - vector(p1))
+    l1, l2 = d1.vlen(), d2.vlen()
+    return l1 == 0 or l2 == 0 or abs(abs(d1.dot(d2) / l1 / l2) - 1) < threshold
+
+def collinearBetween(p1, p2, p3, threshold=1e-8):
+    'Test if three points are collinear with p2 between p1 and p3'
+    d1, d2 = vector(vector(p1) - vector(p2)), vector(vector(p3) - vector(p2))
+    l1, l2 = d1.vlen(), d2.vlen()
+    return l1 == 0 or l2 == 0 or abs(d1.dot(d2) / l1 / l2 + 1) < threshold
+
 def distance2(point1, point2):
     return vector(vector(point1) - vector(point2)).len2()
 

--- a/PythonVisualizations/runAllVisualizationsMenu.py
+++ b/PythonVisualizations/runAllVisualizationsMenu.py
@@ -230,6 +230,13 @@ def resizeHandler(event):
         print('Resize of application window', event.widget, 'to',
               event.widget.winfo_width(), 'x', event.widget.winfo_height())
 
+def genericEventHandler(event):
+    if event.widget in appWindows:
+        appTitle = getattr(event.widget, 'appTitle', '')
+        if appTitle: appTitle += ' '
+        print('{} event on {}application window {}'.format(
+            event.type, appTitle, event.widget))
+        
 def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
         classes, start=None, title="Algorithm Visualizations", 
         adjustForTrinket=False, seed='3.14159', verbose=0):
@@ -307,7 +314,12 @@ def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
             appWindows.append(pane)
             try:
                 vizApp = app(window=pane)
-                name = folder + ': ' + getattr(vizApp, 'title', app.__name__)
+                appTitle = getattr(vizApp, 'title', app.__name__)
+                name = folder + ': ' + appTitle
+                setattr(pane, 'appTitle', appTitle)
+                if verbose > 0:
+                    for eventType in ('<Map>', '<Visibility>'):
+                        pane.bind(eventType, genericEventHandler, '+')
             except Exception as e:
                 name = app.__name__ + ' *'
                 msg = 'Error instantiating {}:\n{}'.format(app.__name__, e)

--- a/PythonVisualizations/tkUtilities.py
+++ b/PythonVisualizations/tkUtilities.py
@@ -3,7 +3,7 @@ Utilty methods and classes for Tk, and in particular, a specialized
 version of canvas called 'Scrim', and a cache of Tk images.
 """
 
-import re, sys, math
+import re, sys, math, os
 from tkinter import *
 from tkinter import ttk
 import tkinter.font as tkfont
@@ -346,15 +346,21 @@ class Scrim(Canvas):
 # Tk image utilities
 __tk_image_cache__ = {'Img': {}, 'PhotoImage': {}, 'debug': False}
 
-def getImage(filename, cache=True):
+def getImage(filename, cache=True, path=None):
     if not cache or filename not in __tk_image_cache__['Img']:
+        if path is None: path = sys.path
+        fname = filename
+        for dir in path:
+            if os.path.exists(os.path.join(dir, filename)):
+                fname = os.path.join(dir, filename)
+                break
         if __tk_image_cache__['debug']:
-            print('Reading {} into Img cache'.format(filename))
-        __tk_image_cache__['Img'][filename] = Img.open(filename)
+            print('Reading {} into Img cache'.format(fame))
+        __tk_image_cache__['Img'][filename] = Img.open(fname)
     return __tk_image_cache__['Img'][filename]
 
-def getPhotoImage(filename, size, cache=True):
-    image = getImage(filename, cache=cache)
+def getPhotoImage(filename, size, cache=True, path=None):
+    image = getImage(filename, cache=cache, path=path)
     if not cache or (id(image), size) not in __tk_image_cache__['PhotoImage']:
         ratio = min(*(V(size) / V(image.size)))
         if __tk_image_cache__['debug']:

--- a/PythonVisualizations/tkUtilities.py
+++ b/PythonVisualizations/tkUtilities.py
@@ -359,9 +359,11 @@ def getPhotoImage(filename, size, cache=True):
         ratio = min(*(V(size) / V(image.size)))
         if __tk_image_cache__['debug']:
             print('Resizing {} into PhotoImage cache with ratio {}'.format(
-                filename, ratio))
+                filename, ratio), end=' ')
         __tk_image_cache__['PhotoImage'][id(image), size] = ImageTk.PhotoImage(
             image.resize(int(round(d)) for d in V(image.size) * ratio))
+        if __tk_image_cache__['debug']:
+            print('as', __tk_image_cache__['PhotoImage'][id(image), size])
     return __tk_image_cache__['PhotoImage'][id(image), size]
     
 if __name__ == '__main__':

--- a/PythonVisualizations/tkUtilities.py
+++ b/PythonVisualizations/tkUtilities.py
@@ -1,5 +1,6 @@
 __doc__ = """
-Utilty methods and classes for Tk, and in particular, canvases and their items.
+Utilty methods and classes for Tk, and in particular, a specialized
+version of canvas called 'Scrim', and a cache of Tk images.
 """
 
 import re, sys, math
@@ -7,6 +8,14 @@ from tkinter import *
 from tkinter import ttk
 import tkinter.font as tkfont
 from enum import Enum
+
+try:
+    from PIL import Image as Img
+    from PIL import ImageTk
+except ModuleNotFoundError as e:
+    print('Pillow module not found.  Did you try running:')
+    print('pip3 install -r requirements.txt')
+    raise e
 
 try:
     from coordinates import *
@@ -333,9 +342,30 @@ class Scrim(Canvas):
 
     def getItemFont(self, item):
         return parseTkFont(self.itemConfig(item, 'font'))
+
+# Tk image utilities
+__tk_image_cache__ = {'Img': {}, 'PhotoImage': {}, 'debug': False}
+
+def getImage(filename, cache=True):
+    if not cache or filename not in __tk_image_cache__['Img']:
+        if __tk_image_cache__['debug']:
+            print('Reading {} into Img cache'.format(filename))
+        __tk_image_cache__['Img'][filename] = Img.open(filename)
+    return __tk_image_cache__['Img'][filename]
+
+def getPhotoImage(filename, size, cache=True):
+    image = getImage(filename, cache=cache)
+    if not cache or (id(image), size) not in __tk_image_cache__['PhotoImage']:
+        ratio = min(*(V(size) / V(image.size)))
+        if __tk_image_cache__['debug']:
+            print('Resizing {} into PhotoImage cache with ratio {}'.format(
+                filename, ratio))
+        __tk_image_cache__['PhotoImage'][id(image), size] = ImageTk.PhotoImage(
+            image.resize(int(round(d)) for d in V(image.size) * ratio))
+    return __tk_image_cache__['PhotoImage'][id(image), size]
     
 if __name__ == '__main__':
-    import random
+    import random, glob, os
 
     for dims in range(2, 4):
         print('=' * 70)
@@ -400,6 +430,21 @@ if __name__ == '__main__':
         widgetState(tkButton, NORMAL) or widgetState(ttkButton, DISABLED)
         or updateButtonState())
 
+    pngFiles = glob.glob(os.path.join('.', '*.png'))
+    if pngFiles:
+        __tk_image_cache__['debug'] = True
+        buttonSize = widgetDimensions(tkButton)
+        height = max(buttonSize[1], textHeight(scrim.getItemFont(buttonState)))
+        images = [getPhotoImage(pngFile, (height, height))
+                  for pngFile in pngFiles]
+        imageButton = Button(tk, image=images[0])
+        imageButton.pack(side=LEFT, expand=TRUE)
+        buttonImage(imageButton, images[0])
+        def rotateButtonImage():
+            i = images.index(buttonImage(imageButton))
+            print('Pressed {} button'.format(pngFiles[i]))
+            buttonImage(imageButton, images[(i + 1) % len(images)])
+        imageButton['command'] = rotateButtonImage
     palette = ('red', 'green', 'blue', '', 'pink', 'black', 'yellow',
                'orange', 'brown')
     nc = len(palette)

--- a/PythonVisualizations/tkUtilities.py
+++ b/PythonVisualizations/tkUtilities.py
@@ -355,7 +355,7 @@ def getImage(filename, cache=True, path=None):
                 fname = os.path.join(dir, filename)
                 break
         if __tk_image_cache__['debug']:
-            print('Reading {} into Img cache'.format(fame))
+            print('Reading {} into Img cache'.format(fname))
         __tk_image_cache__['Img'][filename] = Img.open(fname)
     return __tk_image_cache__['Img'][filename]
 


### PR DESCRIPTION
This PR should close #245 by implementing the minimum spanning tree for weighted graphs.  
It also makes both weighted and unweighted graphs:

- use an empty ring to represent bad positioning of vertices
- mark vertex positions on a line segment between bidirectionally connected vertices as being "bad"
- update all connected edges and the selected vertex ring as a vertex is dragged around to acceptable positions (instead of updating only after the drag is released).
- move the `inb` and `outb` variables to the right edge during the `degree()` routine to avoid  overlaps with the many `vertsByDegree` hash tables.
![Screen Shot 2021-07-29 at 10 37 47 AM](https://user-images.githubusercontent.com/26984827/127539033-6330d95b-acae-44d3-b6f6-e10e750141f1.png)
