### PR TITLE
Issue246 Look for more visualization apps in runAllVisualizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea
 __pycache__/
 *.log
+venv/

--- a/AlgorithmVisualizations.py
+++ b/AlgorithmVisualizations.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 __doc__ = """
-Program to show algorithm visualizations in a nested tabbed Tk notebook.
+Program to show algorithm visualizations in a single application.
 """
 
 from PythonVisualizations import runAllVisualizationsMenu

--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -1094,4 +1094,4 @@ if __name__ == '__main__':
     for fromVert, toVert, weight in edges:
         graph.createEdge(fromVert, toVert, weight)
         
-    graph.runVisualization()
+    graph.runVisualization() # runAllVisualizations ignore

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -244,8 +244,6 @@ class VisualizationApp(Visualization): # Base class for visualization apps
                 helpTexts = getattr(textEntry, 'helpTexts', set())
                 helpTexts.add(help)
                 setattr(textEntry, 'helpTexts', helpTexts)
-            if argHelpText: # Make a label if there are hints on what to enter
-                self.setHint()
 
             # Place button in grid of buttons
             buttonColumn = self.withArgsColumn + len(withArgs) // maxRows
@@ -331,6 +329,12 @@ class VisualizationApp(Visualization): # Base class for visualization apps
             self.entryHint.bind(
                 '<Shift-Button>', # Extend hint activation delay
                 self.extendHintActivationHandler())
+            lastRow = max(int(op.grid_info()['row'])
+                          for op in self.operations.grid_slaves()
+                          if (isinstance(op, (self.buttonTypes, Frame))))
+            self.entryHint.grid(column=self.argsColumn,
+                                row=max(len(self.textEntries) + 1, lastRow))
+
         else:                      # Update hint text if already present
             self.entryHint['text'] = hintText
             if hintText == '':
@@ -1029,6 +1033,11 @@ class VisualizationApp(Visualization): # Base class for visualization apps
             self.argumentChanged()
         # Otherwise, let animation be stopped by a lower call
 
+    def runVisualization(self):
+        if self.textEntries:  # Make initial hint if there are text entry areas
+            self.setHint()
+        self.window.mainloop()
+        
 # Tk widget utilities
 
 def clearHintHandler(hintLabel, textEntry=None):

--- a/PythonVisualizations/allVisualizationsCommon.py
+++ b/PythonVisualizations/allVisualizationsCommon.py
@@ -1,0 +1,166 @@
+#! /usr/bin/env python3
+__doc__ = """
+Common components of the runAllVisualization tools.
+"""
+
+import sys, re, webbrowser, os, glob
+from importlib import *
+from tkinter import ttk
+
+try:
+    import VisualizationApp
+    VAP = VisualizationApp.VisualizationApp
+except ModuleNotFoundError:
+    from .VisualizationApp import VisualizationApp as VAP
+    
+pathsep = re.compile(r'[/\\]')
+
+def findVisualizations(filesAndDirectories, verbose=0):
+    global __path__
+    classes = set()
+    try:
+        orig__path__ = __path__
+    except NameError:
+        orig__path__ = None
+        __path__ = []
+    for fileOrDir in filesAndDirectories:
+        isDir = os.path.isdir(fileOrDir)
+        files = glob.glob(os.path.join(fileOrDir, '*.py')) if isDir else [
+                   fileOrDir]
+        if verbose > 1:
+            print(
+                'Looking for "runVisualization()" in',
+                '{} python files in {}'.format(len(files), fileOrDir) if isDir
+                else fileOrDir,
+                file=sys.stderr)
+            if verbose > 2 and isDir:
+                print('Files:', '\n'.join(files), file=sys.stderr)
+        for filename in [f for f in files 
+                         if isStringInFile('runVisualization()', f)]:
+            dirs = pathsep.split(os.path.normpath(os.path.dirname(filename)))
+            if dirs and dirs[0] == '.':
+                dirs.pop(0)
+            modulename, ext = os.path.splitext(os.path.basename(filename))
+            if modulename:
+                try:
+                    path = '/'.join(dirs)
+                    addPath = path and not path in __path__
+                    if verbose > 1:
+                        if addPath:
+                            print('Adding {} to __path__ ...'.format(path),
+                                  file=sys.stderr)
+                        print('Attempting to import {} ... ' .format(
+                            modulename), file=sys.stderr, end='')
+                    if addPath:
+                        __path__.append(path) 
+                    module = import_module(modulename)
+                    if verbose > 1:
+                        print('Imported. Looking for VisualizationApp'
+                              .format(modulename), file=sys.stderr)
+                    newclasses = findVisualizationClasses(module, verbose)
+                    if verbose > 1:
+                        print('Found {} matching classes: {}'
+                              .format(len(newclasses), newclasses),
+                              file=sys.stderr)
+                        previouslyFound = set(newclasses) & classes
+                        if len(previouslyFound) > 0:
+                            print('Previously found:', previouslyFound,
+                                  file=sys.stderr)
+                    classes |= set(newclasses)
+                except ModuleNotFoundError:
+                    if verbose > 0:
+                        print('Unable to import module', modulename,
+                              file=sys.stderr)
+    if orig__path__ is not None:
+        __path__ = orig__path__
+    return classes
+    
+def isStringInFile(text, filename):
+    with open(filename, 'r') as f:
+        return text in f.read()
+            
+def findVisualizationClasses(module, verbose=0):
+    classes = []
+    for name in dir(module):
+        this = getattr(module, name)          # Check if this 
+        if (isinstance(this, type(object)) and # is a class
+            issubclass(this, VAP) and this is not VAP and # a subclass of VAP
+            this.__module__ == module.__name__): # defined in ths module
+            classes.append(this)
+        elif verbose > 2:
+            print('Ignoring {}.{} of type {}'.format(
+                module.__name__, name, type(this)), file=sys.stderr)
+    return classes
+
+URL_pattern = re.compile(r'(https*|ftp)://[\w-]+\.[\w/.,?&=#%-]+')
+
+intro_msg = """
+Welcome to the algorithm visualizations for the book:
+Data Structures and Algorithms in Python
+
+Please use these visualization tools along with the book to improve
+your understanding of how computers organize and manipulate data
+efficiently.
+
+{customInstructions}
+
+Exceptional students in the Computer Science Department of
+Stern College at Yeshiva University developed these visualizations.
+https://www.yu.edu/stern/ug/computer-science
+"""
+
+def openURL(URL):         # Make a callback function to open an URL
+    return lambda e: webbrowser.open(URL)
+
+INTRO_FONT = ('Helvetica', -16)
+
+def makeIntro(
+        mesg, container, font=INTRO_FONT, URLfg='blue', 
+        URLfont=INTRO_FONT + ('underline',), row=0, column=0):
+    '''Make introduction screen as a sequence of labels for each line of a
+    a message.  The labels are stacked, centered inside a container
+    widget.  URLs are converted to a label within a frame that has a
+    binding to open the URL.
+    Increment row for each line added and return the grid row for the
+    next row of the container.
+    '''
+    for line in mesg.split('\n'):
+        URLs = ([m for m in URL_pattern.finditer(line)] if URLfg and URLfont 
+                else [])
+        if URLs:
+            URLframe = ttk.Frame(container, cursor='hand2')
+            last = 0
+            col = 0
+            for match in URLs:
+                if match.start() > last:
+                    label = ttk.Label(URLframe, text=line[last:match.start()],
+                                      font=font)
+                    label.grid(row=0, column=col)
+                    col += 1
+                link = ttk.Label(
+                    URLframe, text=match.group(), font=URLfont,
+                    foreground=URLfg)
+                link.grid(row=0, column=col)
+                col += 1
+                link.bind('<Button-1>', openURL(match.group()))
+                last = match.end()
+            if last < len(line):
+                label = ttk.Label(URLframe, text=line[last:], 
+                                  font=font)
+                label.grid(row=0, column=col)
+                col += 1
+            URLframe.grid(row=row, column=column)
+        else:
+            label = ttk.Label(container, text=line, font=font)
+            label.grid(row=row, column=column)
+        row += 1
+    return row
+
+def oneTimeShowHintHandler(visualizationApp, hintText=None, delay=500):
+    'Creates an event handler to set the application hint after a delay'
+    return lambda event: (
+        getattr(visualizationApp, 'initial_hint_shown', False) or
+        visualizationApp.window.after(
+            delay, lambda: visualizationApp.setHint(hintText)) and
+        setattr(visualizationApp, 'initial_hint_shown', True))
+        

--- a/PythonVisualizations/runAllVisualizations.py
+++ b/PythonVisualizations/runAllVisualizations.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 __doc__ = """ 
 Program to show algorithm visualizations in a tabbed Tk notebook
 presentation form.  This program loads all the visualization modules

--- a/PythonVisualizations/runAllVisualizations.py
+++ b/PythonVisualizations/runAllVisualizations.py
@@ -15,9 +15,11 @@ from tkinter import *
 from tkinter import ttk
 
 try:
+    from allVisualizationsCommon import *
     import VisualizationApp
     VAP = VisualizationApp.VisualizationApp
 except ModuleNotFoundError:
+    from .allVisualizationsCommon import *
     from .VisualizationApp import VisualizationApp as VAP
 
 PREFERRED_ARRANGEMENT = [
@@ -33,92 +35,9 @@ PREFERRED_ARRANGEMENT = [
      ['HashTableOpenAddressing', 'HashTableChaining', 'Heap', 
       'Graph', 'WeightedGraph', 'BloomFilter', 'SkipList']],
     ]
-
-pathsep = re.compile(r'[/\\]')
-
-def findVisualizations(filesAndDirectories, verbose=0):
-    classes = set()
-    for fileOrDir in filesAndDirectories:
-        isDir = os.path.isdir(fileOrDir)
-        files = glob.glob(os.path.join(fileOrDir, '*.py')) if isDir else [
-                   fileOrDir]
-        if verbose > 1:
-            print(
-                'Looking for "runVisualization()" in',
-                '{} python files in {}'.format(len(files), fileOrDir) if isDir
-                else fileOrDir,
-                file=sys.stderr)
-            if verbose > 2 and isDir:
-                print('Files:', '\n'.join(files), file=sys.stderr)
-        for filename in [f for f in files 
-                         if isStringInFile('runVisualization()', f)]:
-            dirs = pathsep.split(os.path.normpath(os.path.dirname(filename)))
-            if dirs and dirs[0] == '.':
-                dirs.pop(0)
-            modulename, ext = os.path.splitext(os.path.basename(filename))
-            if modulename:
-                try:
-                    fullmodulename = '.'.join(dirs + [modulename])
-                    if verbose > 1:
-                        print('Attempting to import {} ... ' .format(
-                            fullmodulename), file=sys.stderr, end='')
-                    module = import_module(fullmodulename)
-                    if verbose > 1:
-                        print('Imported. Looking for VisualizationApp'
-                              .format(fullmodulename),
-                              file=sys.stderr)
-                    newclasses = findVisualizationClasses(module, verbose)
-                    if verbose > 1:
-                        print('Found {} matching classes: {}'
-                              .format(len(newclasses), newclasses),
-                              file=sys.stderr)
-                        previouslyFound = set(newclasses) & classes
-                        if len(previouslyFound) > 0:
-                            print('Previously found:', previouslyFound,
-                                  file=sys.stderr)
-                    classes |= set(newclasses)
-                except ModuleNotFoundError:
-                    if verbose > 0:
-                        print('Unable to import module', modulename,
-                              file=sys.stderr)
-    return classes
     
-def isStringInFile(text, filename):
-    with open(filename, 'r') as f:
-        return text in f.read()
-            
-def findVisualizationClasses(module, verbose=0):
-    classes = []
-    for name in dir(module):
-        this = getattr(module, name)          # Check if this 
-        if (isinstance(this, type(object)) and # is a class
-            issubclass(this, VAP) and this is not VAP and # a subclass of VAP
-            this.__module__ == module.__name__): # defined in ths module
-            classes.append(this)
-        elif verbose > 2:
-            print('Ignoring {}.{} of type {}'.format(
-                module.__name__, name, type(this)), file=sys.stderr)
-    return classes
-
-URL_pattern = re.compile(r'(https*|ftp)://[\w-]+\.[\w/.,?&=#%-]+')
-
 TAB_FONT = ('Calibri', -16)
 INTRO_FONT = ('Helvetica', -16)
-
-intro_msg = """
-Welcome to the algorithm visualizations for the book:
-Data Structures and Algorithms in Python
-
-Please use these visualization tools along with the book to improve
-your understanding of how computers organize and manipulate data
-efficiently.
-
-{customInstructions}
-
-Exceptional students in the Computer Science Department of
-Stern College at Yeshiva University developed these visualizations.
-https://www.yu.edu/stern/ug/computer-science
-"""
 
 desktopInstructions = '''
 Select a chapter and a visualization from the tabs at the top to see the
@@ -131,51 +50,6 @@ different data structures.  If you are viewing this in a browser on a
 touch screen device, you may not be allowed to click on text entry
 boxes and use the soft keyboard to enter values.
 '''
-
-def openURL(URL):         # Make a callback function to open an URL
-    return lambda e: webbrowser.open(URL)
-
-def makeIntro(
-        mesg, container, font=INTRO_FONT, URLfg='blue', 
-        URLfont=INTRO_FONT + ('underline',), row=0, column=0):
-    '''Make introduction screen as a sequence of labels for each line of a
-    a message.  The labels are stacked, centered inside a container
-    widget.  URLs are converted to a label within a frame that has a
-    binding to open the URL.
-    Increment row for each line added and return the grid row for the
-    next row of the container.
-    '''
-    for line in mesg.split('\n'):
-        URLs = ([m for m in URL_pattern.finditer(line)] if URLfg and URLfont 
-                else [])
-        if URLs:
-            URLframe = ttk.Frame(container, cursor='hand2')
-            last = 0
-            col = 0
-            for match in URLs:
-                if match.start() > last:
-                    label = ttk.Label(URLframe, text=line[last:match.start()],
-                                      font=font)
-                    label.grid(row=0, column=col)
-                    col += 1
-                link = ttk.Label(
-                    URLframe, text=match.group(), font=URLfont,
-                    foreground=URLfg)
-                link.grid(row=0, column=col)
-                col += 1
-                link.bind('<Button-1>', openURL(match.group()))
-                last = match.end()
-            if last < len(line):
-                label = ttk.Label(URLframe, text=line[last:], 
-                                  font=font)
-                label.grid(row=0, column=col)
-                col += 1
-            URLframe.grid(row=row, column=column)
-        else:
-            label = ttk.Label(container, text=line, font=font)
-            label.grid(row=row, column=column)
-        row += 1
-    return row
 
 def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
         classes, start=None, title="Algorithm Visualizations", 
@@ -237,6 +111,8 @@ def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
             try:
                 vizApp = app(window=pane)
                 name = getattr(vizApp, 'title', app.__name__)
+                pane.bind('<Map>', oneTimeShowHintHandler(vizApp), '+')
+
             except Exception as e:
                 name = app.__name__
                 msg = 'Error instantiating {}:\n{}'.format(name, e)
@@ -287,6 +163,10 @@ if __name__ == '__main__':
         '-t', '--title',  default='Algorithm Visualizations',
         help='Title for top level window')
     parser.add_argument(
+        '-w', '--warn-for-trinket', default=False, action='store_true',
+        help='Adjust settings and warn users about limitations of use on '
+        'Trinket.io')
+    parser.add_argument(
         '--seed', default='3.14159',
         help='Random number generator seed.  Set to empty string to skip '
         'seeding.')
@@ -296,8 +176,18 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.files is None or args.files == []:
-        args.files = [os.path.dirname(sys.argv[0]) or
-                      os.path.relpath(os.getcwd())]
+        dirs = set([os.path.relpath(os.getcwd())])
+        if sys.argv and os.path.dirname(sys.argv[0]):
+            dirs.add(os.path.dirname(sys.argv[0]))
+        try:
+            dirs.add(os.path.dirname(__file__))
+        except:
+            pass
+        if args.verbose > 1:
+            print('No files provided.  Unique directories to search:', dirs,
+                  'with search order:', list(dirs))
+        args.files = list(dirs)
     showVisualizations(findVisualizations(args.files, args.verbose),
                        start=args.start, title=args.title, verbose=args.verbose,
+                       adjustForTrinket=args.warn_for_trinket,
                        seed=args.seed)

--- a/PythonVisualizations/runAllVisualizationsMenu.py
+++ b/PythonVisualizations/runAllVisualizationsMenu.py
@@ -18,10 +18,12 @@ from tkinter import *
 from tkinter import ttk
 
 try:
+    from allVisualizationsCommon import *
     import VisualizationApp
     VAP = VisualizationApp.VisualizationApp
 except ModuleNotFoundError:
     from .VisualizationApp import VisualizationApp as VAP
+    from .allVisualizationsCommon import *
 
 PREFERRED_ARRANGEMENT = [
     ['Chapter 2', ['Array', 'OrderedArray']],
@@ -41,91 +43,8 @@ PREFERRED_ARRANGEMENT = [
     ['Chapter 16', ['BloomFilter', 'SkipList']],
     ]
 
-pathsep = re.compile(r'[/\\]')
-
-def findVisualizations(filesAndDirectories, verbose=0):
-    classes = set()
-    for fileOrDir in filesAndDirectories:
-        isDir = os.path.isdir(fileOrDir)
-        files = glob.glob(os.path.join(fileOrDir, '*.py')) if isDir else [
-                   fileOrDir]
-        if verbose > 1:
-            print(
-                'Looking for "runVisualization()" in',
-                '{} python files in {}'.format(len(files), fileOrDir) if isDir
-                else fileOrDir,
-                file=sys.stderr)
-            if verbose > 2 and isDir:
-                print('Files:', '\n'.join(files), file=sys.stderr)
-        for filename in [f for f in files 
-                         if isStringInFile('runVisualization()', f)]:
-            dirs = pathsep.split(os.path.normpath(os.path.dirname(filename)))
-            if dirs and dirs[0] == '.':
-                dirs.pop(0)
-            modulename, ext = os.path.splitext(os.path.basename(filename))
-            if modulename:
-                try:
-                    fullmodulename = '.'.join(dirs + [modulename])
-                    if verbose > 1:
-                        print('Attempting to import {} ... ' .format(
-                            fullmodulename), file=sys.stderr, end='')
-                    module = import_module(fullmodulename)
-                    if verbose > 1:
-                        print('Imported. Looking for VisualizationApp'
-                              .format(fullmodulename),
-                              file=sys.stderr)
-                    newclasses = findVisualizationClasses(module, verbose)
-                    if verbose > 1:
-                        print('Found {} matching classes: {}'
-                              .format(len(newclasses), newclasses),
-                              file=sys.stderr)
-                        previouslyFound = set(newclasses) & classes
-                        if len(previouslyFound) > 0:
-                            print('Previously found:', previouslyFound,
-                                  file=sys.stderr)
-                    classes |= set(newclasses)
-                except ModuleNotFoundError:
-                    if verbose > 0:
-                        print('Unable to import module', modulename,
-                              file=sys.stderr)
-    return classes
-    
-def isStringInFile(text, filename):
-    with open(filename, 'r') as f:
-        return text in f.read()
-            
-def findVisualizationClasses(module, verbose=0):
-    classes = []
-    for name in dir(module):
-        this = getattr(module, name)          # Check if this 
-        if (isinstance(this, type(object)) and # is a class
-            issubclass(this, VAP) and this is not VAP and # a subclass of VAP
-            this.__module__ == module.__name__): # defined in ths module
-            classes.append(this)
-        elif verbose > 2:
-            print('Ignoring {}.{} of type {}'.format(
-                module.__name__, name, type(this)), file=sys.stderr)
-    return classes
-
-URL_pattern = re.compile(r'(https*|ftp)://[\w-]+\.[\w/.,?&=#%-]+')
-
 INTRO_FONT = ('Helvetica', -16)
 MENU_FONT = ('Helvetica', -12)
-
-intro_msg = """
-Welcome to the algorithm visualizations for the book:
-Data Structures and Algorithms in Python
-
-Please use these visualization tools along with the book to improve
-your understanding of how computers organize and manipulate data
-efficiently.
-
-{customInstructions}
-
-Exceptional students in the Computer Science Department of
-Stern College at Yeshiva University developed these visualizations.
-https://www.yu.edu/stern/ug/computer-science
-"""
 
 desktopInstructions = '''
 Select a visualization from the menu at the top to see the
@@ -140,51 +59,6 @@ different data structures.  If you are viewing this in a browser on a
 touch screen device, you may not be allowed to click on text entry
 boxes and use the soft keyboard to enter values.
 '''
-
-def openURL(URL):         # Make a callback function to open an URL
-    return lambda e: webbrowser.open(URL)
-
-def makeIntro(
-        mesg, container, font=INTRO_FONT, URLfg='blue', 
-        URLfont=INTRO_FONT + ('underline',), row=0, column=0):
-    '''Make introduction screen as a sequence of labels for each line of a
-    a message.  The labels are stacked, centered inside a container
-    widget.  URLs are converted to a label within a frame that has a
-    binding to open the URL.
-    Increment row for each line added and return the grid row for the
-    next row of the container.
-    '''
-    for line in mesg.split('\n'):
-        URLs = ([m for m in URL_pattern.finditer(line)] if URLfg and URLfont 
-                else [])
-        if URLs:
-            URLframe = ttk.Frame(container, cursor='hand2')
-            last = 0
-            col = 0
-            for match in URLs:
-                if match.start() > last:
-                    label = ttk.Label(URLframe, text=line[last:match.start()],
-                                      font=font)
-                    label.grid(row=0, column=col)
-                    col += 1
-                link = ttk.Label(
-                    URLframe, text=match.group(), font=URLfont,
-                    foreground=URLfg)
-                link.grid(row=0, column=col)
-                col += 1
-                link.bind('<Button-1>', openURL(match.group()))
-                last = match.end()
-            if last < len(line):
-                label = ttk.Label(URLframe, text=line[last:], 
-                                  font=font)
-                label.grid(row=0, column=col)
-                col += 1
-            URLframe.grid(row=row, column=column)
-        else:
-            label = ttk.Label(container, text=line, font=font)
-            label.grid(row=row, column=column)
-        row += 1
-    return row
 
 appWindows = []
 userSelectedWindow = None
@@ -308,6 +182,8 @@ def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
             try:
                 vizApp = app(window=pane)
                 name = folder + ': ' + getattr(vizApp, 'title', app.__name__)
+                pane.bind('<Map>', oneTimeShowHintHandler(vizApp), '+')
+                
             except Exception as e:
                 name = app.__name__ + ' *'
                 msg = 'Error instantiating {}:\n{}'.format(app.__name__, e)
@@ -374,8 +250,17 @@ if __name__ == '__main__':
     args = parser.parse_args()
         
     if args.files is None or args.files == []:
-        args.files = [os.path.dirname(sys.argv[0]) or
-                      os.path.relpath(os.getcwd())]
+        dirs = set([os.path.relpath(os.getcwd())])
+        if sys.argv and os.path.dirname(sys.argv[0]):
+            dirs.add(os.path.dirname(sys.argv[0]))
+        # try:
+        #     dirs.add(os.path.dirname(__file__))
+        # except:
+        #     pass
+        if args.verbose > 1:
+            print('No files provided.  Unique directories to search:', dirs,
+                  'with search order:', list(dirs))
+        args.files = list(dirs)
     showVisualizations(findVisualizations(args.files, args.verbose),
                        start=args.start, title=args.title, verbose=args.verbose,
                        adjustForTrinket=args.warn_for_trinket,

--- a/PythonVisualizations/runAllVisualizationsMenu.py
+++ b/PythonVisualizations/runAllVisualizationsMenu.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 __doc__ = """
 Program to show algorithm visualizations one at at time with a
 dropdown menu to select one.  This program loads all the visualization

--- a/PythonVisualizations/runAllVisualizationsMenu.py
+++ b/PythonVisualizations/runAllVisualizationsMenu.py
@@ -22,8 +22,8 @@ try:
     import VisualizationApp
     VAP = VisualizationApp.VisualizationApp
 except ModuleNotFoundError:
-    from .VisualizationApp import VisualizationApp as VAP
     from .allVisualizationsCommon import *
+    from .VisualizationApp import VisualizationApp as VAP
 
 PREFERRED_ARRANGEMENT = [
     ['Chapter 2', ['Array', 'OrderedArray']],

--- a/PythonVisualizations/runAllVisualizationsMenu.py
+++ b/PythonVisualizations/runAllVisualizationsMenu.py
@@ -253,10 +253,10 @@ if __name__ == '__main__':
         dirs = set([os.path.relpath(os.getcwd())])
         if sys.argv and os.path.dirname(sys.argv[0]):
             dirs.add(os.path.dirname(sys.argv[0]))
-        # try:
-        #     dirs.add(os.path.dirname(__file__))
-        # except:
-        #     pass
+        try:
+            dirs.add(os.path.dirname(__file__))
+        except:
+            pass
         if args.verbose > 1:
             print('No files provided.  Unique directories to search:', dirs,
                   'with search order:', list(dirs))


### PR DESCRIPTION
This PR should close #246 by finding all the visualization applications in the same directory as the runAllVisualizations.py and runAllVisualizationsMenu.py file.  It modifies the `sys.path` temporarily to include the directory where the runAll file is and that is used both to find the visualizations as well as the ancillary image files used for button labels.  It also ensures that the default application hint appears on the first time the application is chosen from the menu or notebook tab.

Hopefully this addresses the issue of not being able to run runAllVisualizationsMenu.py from within an IDE environment.
