### PR TITLE
Issue249 Add Dijkstra's shortest path

### DIFF
--- a/PythonVisualizations/Graph.py
+++ b/PythonVisualizations/Graph.py
@@ -1255,7 +1255,7 @@ def degree(self, n={nVal}):
                     self.breadthFirstTraverseButton, self.MSTButton):
             widgetState( # can only traverse when start node selected
                 btn,
-                NORMAL if enable and self.selectedVertex else DISABLED)
+                NORMAL if enable and self.selectedVertices[0] else DISABLED)
         widgetState(  # Can only sort directional graphs with 1+ edges
             self.sortButton,
             NORMAL if enable and self.nEdges() > 0 and
@@ -1281,18 +1281,18 @@ def degree(self, n={nVal}):
         self.addAnimationButtons()
 
     def clickTraverse(self, kind):
-        if self.selectedVertex:
-            self.traverseExample(kind, self.selectedVertex[0],
+        if self.selectedVertices[0]:
+            self.traverseExample(kind, self.selectedVertices[0][0],
                                  start=self.startMode())
         else:
             self.setMessage('Must select start vertex before traversal')
 
     def clickMinimumSpanningTree(self):
-        if self.selectedVertex:
-            self.minimumSpanningTree(self.selectedVertex[0],
+        if self.selectedVertices[0]:
+            self.minimumSpanningTree(self.selectedVertices[0][0],
                                      start=self.startMode())
         else:
-            self.setMessage('Must select start vertex before traversal')
+            self.setMessage('Must select start vertex for tree')
 
     def clickTopologicalSort(self):
         if self.bidirectionalEdges.get():

--- a/PythonVisualizations/TableDisplay.py
+++ b/PythonVisualizations/TableDisplay.py
@@ -158,6 +158,14 @@ class Table(list):     # Display a table (array/list) in a visualization app
 
     def cellCenter(self, indexOrCoords):
         return BBoxCenter(self.cellCoords(indexOrCoords))
+
+    def cellAndCenters(self, indexOrCoords, rows=1):
+        'Return the cell and center coords for a cell with N rows of text '
+        Vy = V(0, self.cellHeight // max(1, rows))
+        Vcenter = V(self.cellCenter(indexOrCoords))
+        textCenters = tuple(Vcenter + V(Vy * (j - rows / 2 + 1/2))
+                            for j in range(max(1, rows)))
+        return (self.cellCoords(indexOrCoords), *textCenters)
     
     def arrayCellCoords(self, indexOrCoords):
         half = self.cellBorderWidth // 2
@@ -269,9 +277,10 @@ if __name__ == '__main__':
                                        Table.populateArgWithCellIndexHandler),))
     print('table1 contains:', table1)
 
-    table2 = Table(app, (100, 300), 'lime', 'apple', 'fig', 'pear',
+    table2 = Table(app, (100, 300),
+                   'lime\n4', 'apple\n10', 'fig\n8\n??', 'pear\n7',
                    label='Stack', vertical=True, direction=-1, see=True,
-                   indicesFont=('Courier', -14), cellWidth=60, cellHeight=30,
+                   indicesFont=('Courier', -14), cellWidth=60, cellHeight=50,
                    eventHandlerPairs=(('<Button-1>', 
                                        Table.populateArgWithCellIndexHandler),))
     print('table2 contains:', table2)
@@ -294,12 +303,15 @@ if __name__ == '__main__':
     count = 0
     for tbl in (table1, table2, table3):
         for i in range(len(tbl)):
+            val = tbl[i].split('\n') if isinstance(tbl[i], str) else [tbl[i]]
+            coords = tbl.cellAndCenters(i, rows=len(val))
             tbl[i] = drawnValue(
                 tbl[i],
                 app.canvas.create_rectangle(
-                    *tbl.cellCoords(i), fill=drawnValue.palette[count],
+                    *coords[0], fill=drawnValue.palette[count],
                     outline='', width=0),
-                app.canvas.create_text(*tbl.cellCenter(i), text=str(tbl[i])))
+                *(app.canvas.create_text(*coords[j + 1], text=str(v))
+                  for j, v in enumerate(val)))
             count = (count + 1) % len(drawnValue.palette)
     print('Filled in', count, 'table cells')
     app.wait(1)

--- a/PythonVisualizations/WeightedGraph.py
+++ b/PythonVisualizations/WeightedGraph.py
@@ -1,5 +1,5 @@
 from tkinter import *
-import re
+import re, math
 
 try:
     from Graph import *
@@ -236,11 +236,11 @@ def minimumSpanningTree(self, n={nVal}):
                     toMove = (*vertLabels, weightLabel)
                     callEnviron |= set(toMove)
                     insertAt = self.edgeInsertPosition(edges, w)
-                    PQcoords = self.edgePriorityQueueCoords(edges, insertAt)
+                    PQcoords = edges.cellAndCenters(insertAt, rows=2)
                     newCoords=(PQcoords[1], PQcoords[1], PQcoords[2])
                     toMove += flat(*(ed.items for ed in edges[insertAt:]))
                     newCoords += flat(*[
-                        self.edgePriorityQueueCoords(edges, j)
+                        edges.cellAndCenters(j, rows=2)
                         for j in range(insertAt + 1, len(edges) + 1)])
                     self.moveItemsLinearly(
                         toMove, newCoords, sleepTime=wait / 10)
@@ -390,22 +390,19 @@ def minimumSpanningTree(self, n={nVal}):
             else:
                 hi = mid - 1
         return lo
-
-    def edgePriorityQueueCoords(self, edges, index):
-        Vy = V(0, textHeight(self.ADJACENCY_MATRIX_FONT) // 2)
-        Vcenter = V(edges.cellCenter(index))
-        return edges.cellCoords(index), Vcenter - Vy, Vcenter + Vy
     
-    def createEdgePriorityQueueEntry(self, edges, edge, weight, insertAt):
-        coords = self.edgePriorityQueueCoords(edges, insertAt)
+    def createEdgePriorityQueueEntry(
+            self, edges, edge, weight, insertAt, tags='edgePQ'):
+        coords = edges.cellAndCenters(insertAt, rows=2)
         rect = self.canvas.create_rectangle(
             *coords[0], fill=self.EDGE_PRIORITY_QUEUE_COLOR,
-            outline='', width=0, tags='edgePQ')
+            outline='', width=0, tags=tags)
         text1 = self.canvas.create_text(
             *coords[1], text='{}-{}'.format(*edge, weight),
-            font=self.ADJACENCY_MATRIX_FONT)
+            font=self.ADJACENCY_MATRIX_FONT, tags=tags)
         text2 = self.canvas.create_text(
-            *coords[2], text=str(weight), font=self.ADJACENCY_MATRIX_FONT)
+            *coords[2], text=str(weight), font=self.ADJACENCY_MATRIX_FONT,
+            tags=tags)
         return drawnValue((edge, weight), rect, text1, text2)
 
     def updateEdgeAndWeightFromQueue(
@@ -421,7 +418,7 @@ def minimumSpanningTree(self, n={nVal}):
         moveTo = [edgeLabelCoords]
         toDispose = []
         if edge is not None:
-            queueFrontCoords = self.edgePriorityQueueCoords(edges, 0)
+            queueFrontCoords = edges.cellAndCenters(0, rows=2)
             toMove += [self.canvas.create_text(
                 *queueFrontCoords[1], text=(' {}' if i else '{} ').format(v),
                 anchor=W if i else E, font=self.ADJACENCY_MATRIX_FONT)
@@ -433,7 +430,7 @@ def minimumSpanningTree(self, n={nVal}):
             moveTo.append(self.canvas.coords(weightLabel))
             toDispose = toMove[1:]
             toMove += list(flat(*(dv.items for dv in edges)))
-            moveTo += list(flat(*(self.edgePriorityQueueCoords(edges, j)
+            moveTo += list(flat(*(edges.cellAndCenters(j, rows=2)
                                   for j in range(len(edges)))))
         self.moveItemsLinearly(toMove, moveTo, sleepTime=wait / 10)
         self.canvas.coords(
@@ -471,8 +468,7 @@ def shortestPath(self, start={startVal}, end={endVal}):
                costs[nextVert][0])
             if (adj not in costs or
                 costs[adj][0] > pathCost):
-               costs[adj] = (
-                  pathCost, nextVert)
+               costs[adj] = (pathCost, nextVert)
    path = []
    while end in visited:
       path.append(end)
@@ -481,6 +477,8 @@ def shortestPath(self, start={startVal}, end={endVal}):
       end = costs[end][1]
    return list(reversed(path))
 '''
+    pathCostAssignPattern = re.compile(
+        r'pathCost = .*\n.*\n.*costs\[nextVert\]\[0\]\)')
     
     def shortestPath(self, start, end, code=shortestPathCode,
                      startAnimations=True, wait=0.1):
@@ -498,12 +496,362 @@ def shortestPath(self, start={startVal}, end={endVal}):
         endVal = "{} ('{}')".format(end, endVert)
         callEnviron = self.createCallEnvironment(
             code=code.format(**locals()), startAnimations=startAnimations)
+
+        startArrowConfig, endArrowConfig = {'anchor': SE},  {'anchor': NE}
+        vertArrowConfig = {'orientation': 10, 'anchor': SW}
+        startArrow = self.vertexTable.createLabeledArrow(
+            start, 'start', **startArrowConfig)
+        startVertArrow = self.createLabeledArrow(
+            startVert, 'start', **vertArrowConfig)
+        endArrow = self.vertexTable.createLabeledArrow(
+            end, 'end', **endArrowConfig)
+        endVertArrow = self.createLabeledArrow(
+            endVert, 'end', **vertArrowConfig)
+        arrows = startArrow + startVertArrow + endArrow + endVertArrow
+        callEnviron |= set(arrows)
+        localVars = arrows
+        faded = (Scrim.FADED_FILL,) * len(arrows)
+
+        self.highlightCode('visited = {}', callEnviron, wait=wait)
+        visited = self.createVisitedTable(self.nVertices(), visible=False)
+        localVars += visited.items()
+        faded += (Scrim.FADED_FILL,
+                  *((Scrim.FADED_OUTLINE,) * (len(visited.items()) - 1)))
         
-        self.setMessage('TBD')
+        self.highlightCode('costs = {start: (0, start)}', callEnviron,
+                           wait=wait)
+        costs = Table(
+            self, (70, self.graphRegion[3] + 40),
+            label='costs', labelAnchor=E, vertical=False,
+            labelFont=self.VARIABLE_FONT, 
+            cellWidth=self.VERTEX_RADIUS * 3, cellHeight=self.VERTEX_RADIUS * 2,
+            see=True, cellBorderWidth=self.vertexTable.cellBorderWidth)
+        localVars += costs.items()
+        faded += (Scrim.FADED_FILL,) * len(costs.items())
+        costs.append(drawnValue(
+            (startVert, 0, startVert),
+            *self.createCostsTableEntry(
+                costs, startVert, (0, startVert),
+                color=self.canvas.itemConfig(self.vertices[startVert].items[0],
+                                             'fill'))))
+        costVertices = (startVert,)
+        callEnviron |= set(costs.items() + costs[0].items)
+        localVars += (costs.items()[-1], *costs[0].items)
+        faded += (Scrim.FADED_OUTLINE,
+                  *((Scrim.FADED_FILL,) * len(costs[0].items)))
+
+        nextVertArrow, costsNextVertArrow = None, None
+        nextVertArrowConfig = {'orientation': 60}
+        nextVertNoneCoords = (-self.VERTEX_RADIUS,
+                              (self.graphRegion[1] + self.graphRegion[3]) // 2)
+        vertexArrow, vertexArrowConfig = None, {'level': 2}
+        vertexArrow2, vertexArrow2Config = None, {'level': -1}
+        adjArrow, costsAdjArrow, adjArrowConfig = None, None, {
+            'orientation': -60, 'level': 2}
+        costLabelCoords = V(self.graphRegion[2:]) + V(50, 15)
+        pathCostLabelCoords = V(costLabelCoords) + V(0, 15)
+        pathCostLabel = None
+        self.highlightCode('end not in visited', callEnviron, wait=wait)
+        while not visited[end].val:
+            self.highlightCode('nextVert, cost = None, math.inf', callEnviron,
+                               wait=wait)
+            nextVert, cost = None, math.inf
+            if nextVertArrow is None:
+                nextVertArrow = self.createLabeledArrow(
+                    nextVertNoneCoords, 'nextVert', **nextVertArrowConfig)
+                costsNextVertArrow = self.createLabeledArrow(
+                    nextVertNoneCoords, 'nextVert', **nextVertArrowConfig)
+                costLabel = self.canvas.create_text(
+                    *costLabelCoords, anchor=E, text='cost = {}'.format(cost),
+                    tags=SPtags, fill=self.VARIABLE_COLOR,
+                    font=self.VARIABLE_FONT)
+                items = (costLabel, *nextVertArrow, *costsNextVertArrow)
+                callEnviron |= set(items)
+                localVars += items
+                faded += (Scrim.FADED_FILL,) * len(items)
+            else:
+                arrowCoords = self.labeledArrowCoords(nextVertNoneCoords,
+                                                      **nextVertArrowConfig)
+                self.moveItemsTo(nextVertArrow + costsNextVertArrow,
+                                 arrowCoords + arrowCoords,
+                                 sleepTime=wait / 10)
+                self.canvas.itemConfig(costLabel,
+                                       text='cost = {}'.format(cost))
+
+            self.highlightCode('vertex in costs', callEnviron, wait=wait)
+            for costIndex in range(len(costs)):
+                vertex = costs[costIndex].val[0]
+                vertexIndex = self.getVertexIndex(vertex)
+                if vertexArrow is None:
+                    vertexArrow = costs.createLabeledArrow(
+                        costIndex, 'vertex', **vertexArrowConfig)
+                    vertexArrow2 = visited.createLabeledArrow(
+                        vertexIndex, 'vertex', **vertexArrow2Config)
+                    arrows = vertexArrow + vertexArrow2
+                    callEnviron |= set(arrows)
+                    localVars += arrows
+                    faded += (Scrim.FADED_FILL,) * len(arrows)
+                else:
+                    self.moveItemsTo(
+                        vertexArrow + vertexArrow2,
+                        costs.labeledArrowCoords(costIndex, **vertexArrowConfig)
+                        + visited.labeledArrowCoords(
+                            vertexIndex, **vertexArrow2Config),
+                        sleepTime=wait / 10)
+
+                self.highlightCode('vertex not in visited', callEnviron,
+                                   wait=wait)
+                if not visited[vertexIndex].val:
+                    self.highlightCode('costs[vertex][0] <= cost', callEnviron,
+                                       wait=wait)
+                if (not visited[vertexIndex].val and
+                    costs[costIndex].val[1] < cost):
+                    self.highlightCode(
+                        'nextVert, cost = vertex, costs[vertex][0]',
+                        callEnviron, wait=wait)
+                    nextVert, nextVertIndex = vertex, vertexIndex
+                    cost = costs[costIndex].val[1]
+                    costCopy = self.canvas.copyItem(costs[costIndex].items[2])
+                    callEnviron.add(costCopy)
+                    self.canvas.itemConfig(costCopy, text=str(cost),
+                                           anchor=E)
+                    self.moveItemsTo(
+                        (costCopy, *nextVertArrow, *costsNextVertArrow),
+                        (self.canvas.coords(costLabel),
+                         *(self.labeledArrowCoords(self.vertexCoords(nextVert),
+                                                   **nextVertArrowConfig) +
+                           costs.labeledArrowCoords(costIndex,
+                                                    **nextVertArrowConfig))),
+                        sleepTime=wait / 10)
+                    self.dispose(callEnviron, costCopy)
+                    self.canvas.itemConfig(
+                        costLabel, text='cost = {}'.format(cost))
+
+                self.highlightCode('vertex in costs', callEnviron, wait=wait)
+
+            self.moveItemsTo(
+                vertexArrow + vertexArrow2,
+                costs.labeledArrowCoords(len(costs), **vertexArrowConfig) +
+                visited.labeledArrowCoords(len(visited), **vertexArrow2Config),
+                sleepTime=wait / 10)
+
+            self.highlightCode('nextVert is None', callEnviron, wait=wait)
+            if nextVert is None:
+                self.highlightCode('break', callEnviron, wait=wait)
+                break
+            
+            self.highlightCode('visited[nextVert] = 1', callEnviron, wait=wait)
+            visited[nextVertIndex] = drawnValue(
+                True,
+                self.canvas.create_text(
+                    *visited.cellCenter(nextVertIndex), text='1',
+                    font=self.ADJACENCY_MATRIX_FONT, tags=SPtags))
+            callEnviron |= set(visited[nextVertIndex].items)
+            localVars += visited[nextVertIndex].items
+            faded += (Scrim.FADED_FILL,)
+
+            self.highlightCode('adj in self.adjacentVertices(nextVert)',
+                               callEnviron, wait=wait)
+            colors = self.canvas.fadeItems(localVars, faded)
+            for adj in self.adjacentVertices(nextVertIndex):
+                self.canvas.restoreItems(localVars, colors, top=False)
+                adjVertex = self.vertexTable[adj].val
+                costVertices = [c.val[0] for c in costs]
+                adjVertexInCosts = adjVertex in costVertices
+                adjVertexIndexInCosts = (
+                    costVertices.index(adjVertex) if adjVertexInCosts else
+                    len(costs))
+                if adjArrow is None:
+                    adjArrow = self.createLabeledArrow(adj, 'adj',
+                                                       **adjArrowConfig)
+                    costsAdjArrow = (
+                        costs.createLabeledArrow(adjVertexIndexInCosts, 'adj',
+                                                 **adjArrowConfig)
+                        if adjVertexInCosts else
+                        self.createLabeledArrow(adj, 'adj', **adjArrowConfig))
+                    arrows = adjArrow + costsAdjArrow
+                    callEnviron |= set(arrows)
+                    localVars += arrows
+                    faded += (Scrim.FADED_FILL,) * len(arrows)
+                else:
+                    self.moveItemsTo(
+                        adjArrow + costsAdjArrow,
+                        self.labeledArrowCoords(adj, **adjArrowConfig) +
+                        (costs.labeledArrowCoords(adjVertexIndexInCosts,
+                                                  **adjArrowConfig)
+                         if adjVertexInCosts else
+                         self.labeledArrowCoords(adj, **adjArrowConfig)),
+                        sleepTime=wait / 10)
+                    
+                self.highlightCode('adj not in visited', callEnviron, wait=wait)
+                if not visited[adj].val:
+                    self.highlightCode(self.pathCostAssignPattern, callEnviron,
+                                       wait=wait)
+                    costIndex = costVertices.index(nextVert)
+                    edge = (nextVert, adjVertex)
+                    edgeWeight = self.edgeWeight(*edge)
+                    cost = costs[costIndex].val[1]
+                    pathCost = edgeWeight + cost
+                    edgeWeightCopy = self.canvas.create_text(
+                        *self.canvas.coords(self.edges[edge].items[1]),
+                        anchor=E, text=str(edgeWeight), tags=SPtags,
+                        font=self.ADJACENCY_MATRIX_FONT)
+                    costCopy = self.canvas.copyItem(costs[costIndex].items[2])
+                    self.canvas.itemConfig(costCopy, text=str(cost), anchor=E)
+                    callEnviron |= set((edgeWeightCopy, costCopy))
+                    self.moveItemsTo(
+                        (edgeWeightCopy, costCopy), (pathCostLabelCoords,) * 2,
+                        sleepTime=wait / 10)
+                    if pathCostLabel is None:
+                        pathCostLabel = self.canvas.create_text(
+                            *pathCostLabelCoords, anchor=E,
+                            text='pathCost = {}'.format(pathCost), tags=SPtags,
+                            fill=self.VARIABLE_COLOR, font=self.VARIABLE_FONT)
+                        callEnviron.add(pathCostLabel)
+                        localVars += (pathCostLabel,)
+                        faded += (Scrim.FADED_FILL,)
+                    else:
+                        self.canvas.itemConfig(
+                            pathCostLabel, text='pathCost = {}'.format(pathCost))
+                    self.dispose(callEnviron, edgeWeightCopy, costCopy)
+                    
+                    self.highlightCode('adj not in costs', callEnviron,
+                                       wait=wait)
+                    if adjVertex in costVertices:
+                        self.highlightCode('costs[adj][0] > pathCost',
+                                           callEnviron, wait=wait)
+                    if (not adjVertexInCosts or
+                        costs[adjVertexIndexInCosts].val[1] > pathCost):
+                        self.highlightCode('costs[adj] = (pathCost, nextVert)',
+                                           callEnviron, wait=wait)
+                        pathCostCopy = self.canvas.create_text(
+                            *pathCostLabelCoords, anchor=E, text=str(pathCost),
+                            font=self.ADJACENCY_MATRIX_FONT)
+                        nextVertCopy = self.canvas.create_text(
+                            *self.vertexCoords(nextVert), anchor=W,
+                            text=' {}'.format(nextVert),
+                            font=self.ADJACENCY_MATRIX_FONT)
+                        toMove = (pathCostCopy, nextVertCopy)
+                        costCellCoords = costs.cellAndCenters(
+                            adjVertexIndexInCosts, rows=2)
+                        moveTo = (costCellCoords[2],) * 2
+                        if not adjVertexInCosts:
+                            toMove += (self.canvas.copyItem(
+                                self.vertices[adjVertex].items[1]),)
+                            moveTo += (costCellCoords[1],)
+                        callEnviron |= set(toMove)
+                        self.moveItemsTo(toMove, moveTo, sleepTime=wait / 10)
+                        costTuple = (pathCost, nextVert)
+                        if adjVertexInCosts:
+                            self.canvas.itemConfig(
+                                costs[adjVertexIndexInCosts].items[2],
+                                text=str(costTuple))
+                            costs[adjVertexIndexInCosts].val = (
+                                adjVertex, *costTuple)
+                        else:
+                            costs.append(drawnValue(
+                                (adjVertex, *costTuple),
+                                *self.createCostsTableEntry(
+                                    costs, adjVertex, costTuple,
+                                    color=self.canvas.itemConfig(
+                                        self.vertices[adjVertex].items[0],
+                                        'fill'))))
+                            localVars += (costs.items()[-1], *costs[-1].items)
+                            faded += (Scrim.FADED_OUTLINE,
+                                      *((Scrim.FADED_FILL,) *
+                                        len(costs[-1].items)))
+                        self.dispose(callEnviron, *toMove)
+
+                self.highlightCode('adj in self.adjacentVertices(nextVert)',
+                                   callEnviron, wait=wait)
+                colors = self.canvas.fadeItems(localVars, faded)
+            
+            self.canvas.restoreItems(localVars, colors, top=False)
+            
+            self.highlightCode('end not in visited', callEnviron, wait=wait)
+            
+        self.highlightCode('path = []', callEnviron, wait=wait)
+        self.dispose(callEnviron,
+                     *costsNextVertArrow, *nextVertArrow,
+                     *(adjArrow if adjArrow else ()))
+        path = Table(
+            self, (costs.x0, costs.y0 + costs.cellHeight + 5),
+            label='path', labelAnchor=E, vertical=False,
+            labelFont=self.VARIABLE_FONT, cellWidth=self.vertexTable.cellWidth,
+            cellHeight=self.vertexTable.cellHeight, see=True,
+            cellBorderWidth=self.vertexTable.cellBorderWidth)
+
+        self.highlightCode('end in visited', callEnviron, wait=wait)
+        endIndexInCosts = (
+            costVertices.index(endVert) if endVert in costVertices else -1)
+        if costsAdjArrow:
+            self.canvas.itemConfig(costsAdjArrow[1], text='end')
+            self.moveItemsTo(
+                costsAdjArrow,
+                costs.labeledArrowCoords(endIndexInCosts, **adjArrowConfig),
+                sleepTime=0, steps=1)
+        else:
+            costs.createLabeledArrow(endIndexInCosts, 'end', **adjArrowConfig)
+        while visited[end].val:
+            self.highlightCode('path.append(end)', callEnviron, wait=wait)
+            copies = tuple(self.canvas.copyItem(i)
+                           for i in self.vertexTable[end].items)
+            callEnviron |= set(copies)
+            self.moveItemsTo(copies, path.cellAndCenters(len(path)),
+                             sleepTime=wait / 10)
+            path.append(drawnValue(endVert, *copies))
+            callEnviron |= set(path.items())
+            if len(path) > 1:
+                edge = tuple(d.val for d in path[-2:])
+                treeEdgeHighlight = self.canvas.create_line(
+                    *self.canvas.coords(self.edges[edge].items[0]),
+                    fill=self.HIGHLIGHTED_EDGE_COLOR, tags=SPtags,
+                    width=self.HIGHLIGHTED_EDGE_WIDTH)
+                self.canvas.lower(treeEdgeHighlight, 'edge')
+                callEnviron.add(treeEdgeHighlight)
+            
+            self.highlightCode('end == start', callEnviron, wait=wait)
+            if end == start:
+                self.highlightCode(('break', 2), callEnviron, wait=wait)
+                break
+            
+            self.highlightCode('end = costs[end][1]', callEnviron, wait=wait)
+            endVert = costs[endIndexInCosts].val[2]
+            end = self.getVertexIndex(endVert)
+            endIndexInCosts = costVertices.index(endVert)
+            self.moveItemsTo(
+                endArrow + endVertArrow + costsAdjArrow,
+                self.vertexTable.labeledArrowCoords(end, **endArrowConfig) +
+                self.labeledArrowCoords(endVert, **vertArrowConfig) +
+                costs.labeledArrowCoords(endIndexInCosts, **adjArrowConfig),
+                sleepTime=wait / 10)
+
+            self.highlightCode('end in visited', callEnviron, wait=wait)
         
         self.highlightCode('list(reversed(path))', callEnviron, wait=wait)
         self.cleanUp(callEnviron)
-    
+        return [d.val for d in reversed(path)]
+
+    def createCostsTableEntry(
+            self, costs, vertex, values, color='white', index=None,
+            tags='costs'):
+        if index is None: index = len(costs)
+        coords = self.costsTableCoords(costs, index)
+        rect = self.canvas.create_rectangle(
+            *coords[0], outline='', width=0, fill=color, tags=tags)
+        vertLabel = self.canvas.create_text(
+            *coords[1], text=vertex, font=self.ADJACENCY_MATRIX_FONT, tags=tags)
+        valuesLabel = self.canvas.create_text(
+            *coords[2], text=str(values), font=self.ADJACENCY_MATRIX_FONT,
+            tags=tags)
+        return rect, vertLabel, valuesLabel
+
+    def costsTableCoords(self, costs, index):
+        coords = costs.cellAndCenters(index, rows=2)
+        center = costs.cellCenter(index)
+        return (*coords[0][:3], center[1]), coords[1], coords[2]
+        
+        
     def enableButtons(self, enable=True):
         super(type(self).__bases__[0], self).enableButtons( # Grandparent
             enable)
@@ -540,9 +888,11 @@ def shortestPath(self, start={startVal}, end={endVal}):
 
     def clickShortestPath(self):
         if all(self.selectedVertices):
-            self.shortestPath(self.selectedVertices[0][0],
-                              self.selectedVertices[1][0],
-                              startAnimations=self.startMode())
+            path = self.shortestPath(self.selectedVertices[0][0],
+                                     self.selectedVertices[1][0],
+                                     startAnimations=self.startMode())
+            self.setMessage('Shortest path: ' + ' '.join(path) if path else
+                            'No path found')
         else:
             self.setMessage('Must select start and end vertices to find path')
             

--- a/PythonVisualizations/WeightedGraph.py
+++ b/PythonVisualizations/WeightedGraph.py
@@ -911,6 +911,16 @@ if __name__ == '__main__':
                 graph.randomFillButton.invoke()
                 graph.setArgument(
                     chr(ord(graph.DEFAULT_VERTEX_LABEL) + int(arg[1:])))
+            elif arg == '-Turala':  # Example from textbook
+                for vert in ('Bl', 'Ce', 'Da', 'Gr', 'Ka', 'Na'):
+                    graph.setArgument(vert)
+                    graph.newVertexButton.invoke()
+                for edge in ('Bl-Ce:22', 'Bl-Da:16', 'Ce-Da:29', 'Ce-Gr:34',
+                             'Ce-Na:65', 'Ce-Ka:26', 'Da-Gr:28', 'Da-Ka:24',
+                             'Gr-Ka:25', 'Gr-Na:30', 'Ka-Na:36'):
+                    edgeMatch = edgePattern.fullmatch(edge)
+                    graph.createEdge(edgeMatch.group(1), edgeMatch.group(2),
+                                     int(edgeMatch.group(4)))
         elif edgeMatch and all(edgeMatch.group(i) in sys.argv[1:] 
                                for i in (1, 2)):
             edges.append((edgeMatch.group(1), edgeMatch.group(2),

--- a/PythonVisualizations/WeightedGraph.py
+++ b/PythonVisualizations/WeightedGraph.py
@@ -296,10 +296,10 @@ def minimumSpanningTree(self, n={nVal}):
                 dValue = edges.pop(0)
                 edge, w = dValue.val
                 self.updateEdgeAndWeightFromQueue(
-                    edge, w, edgeLabel, wLabel, highligtedEdge, edges, dValue,
+                    edge, w, edgeLabel, wLabel, highlightedEdge, edges, dValue,
                     nVertsBBox, callEnviron, wait)
 
-                self.highlightCode('not edges.isEmpty() TBD', callEnviron,
+                self.highlightCode('not edges.isEmpty()', callEnviron,
                                    wait=wait)
                 if len(edges) > 0:
                     self.highlightCode('vMap[edge[1]] is not None', callEnviron,
@@ -911,13 +911,18 @@ if __name__ == '__main__':
                 graph.randomFillButton.invoke()
                 graph.setArgument(
                     chr(ord(graph.DEFAULT_VERTEX_LABEL) + int(arg[1:])))
-            elif arg == '-Turala':  # Example from textbook
+            elif arg in ('-TuralaMST', '-TuralaSP'):  # Examples from textbook
                 for vert in ('Bl', 'Ce', 'Da', 'Gr', 'Ka', 'Na'):
                     graph.setArgument(vert)
                     graph.newVertexButton.invoke()
-                for edge in ('Bl-Ce:22', 'Bl-Da:16', 'Ce-Da:29', 'Ce-Gr:34',
-                             'Ce-Na:65', 'Ce-Ka:26', 'Da-Gr:28', 'Da-Ka:24',
-                             'Gr-Ka:25', 'Gr-Na:30', 'Ka-Na:36'):
+                for edge in (
+                        ('Bl-Ce:31', 'Bl-Da:24', 'Ce-Da:35', 'Ce-Gr:49',
+                         'Ce-Na:87', 'Ce-Ka:38', 'Da-Gr:41', 'Da-Ka:52',
+                         'Gr-Ka:25', 'Gr-Na:46', 'Ka-Na:43')
+                        if arg == '-TuralaMST' else
+                        ('Bl-Ce:22', 'Bl-Da:16', 'Ce-Da:29', 'Ce-Gr:34',
+                         'Ce-Na:65', 'Ce-Ka:26', 'Da-Gr:28', 'Da-Ka:24',
+                         'Gr-Ka:25', 'Gr-Na:30', 'Ka-Na:36')):
                     edgeMatch = edgePattern.fullmatch(edge)
                     graph.createEdge(edgeMatch.group(1), edgeMatch.group(2),
                                      int(edgeMatch.group(4)))

--- a/PythonVisualizations/tkUtilities.py
+++ b/PythonVisualizations/tkUtilities.py
@@ -100,6 +100,8 @@ def filterDict(d, filter=lambda key: True):
 # Tk definitions
 # Modifier key constants
 SHIFT, CAPS_LOCK, CTRL, ALT = 0x01, 0x02, 0x04, 0x08
+# Mouse button constants
+MOUSE_BUTTON_1, MOUSE_BUTTON_2, MOUSE_BUTTON_3 = 0x0100, 0x0200, 0x0400
 
 # Window geometry specification strings
 geomPattern = re.compile(r'(\d+)[\sXx]+(\d+)([+-])(-?\d+)([+-])(-?\d+)')


### PR DESCRIPTION
This should close #249 by implementing the shortest path in the WeightedGraph app.  I chose to make the specification of the two endpoints by clicking on vertices rather than adding a text entry box.  It seemed unlikely to me that users would want to type vertex names in the text entry areas and copying them by clicking is nearly the same as simply clicking to get a highlight.  I did make it so only the WeightedGraph app allows a second selected vertex.  It now allows both the Shift key or the use of another mouse button as the way to select the second (ending) vertex and to start dragging a vertex to a new location. 