### PR TITLE
Select all text in entries on FocusIn and restrict edge weight range

### DIFF
--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -295,6 +295,8 @@ class VisualizationApp(Visualization): # Base class for visualization apps
             self.operations, width=self.maxArgWidth * 5 // 4, bg=self.ENTRY_BG,
             validate='key', validatecommand=validationCmd, 
             font=self.CONTROLS_FONT)
+        entry.bind('<FocusIn>', lambda event:
+                   event.widget.select_range(0, END), '+')
         entry.bind(
             '<KeyRelease>', lambda ev: self.argumentChanged(ev.widget), '+')
         for key in ('Return', 'KP_Enter'):


### PR DESCRIPTION
This PR should close #252 by changing the behavior of text entry widgets.  When the keyboard focus shifts to a text entry, all the existing contents are selected (and will be replaced if anything printable characters are typed).  This applies to the edge weight entries as well as all operations arguments (across all applications).  Additionally, typing keys that move the insertion cursor or change the keyboard focus no cause the insertion cursor to jump to the last position.  In one case, the insertion cursor jumps unexpectedly: if the insertion cursor is between two digits and Backspace is pressed to erase the leftmost digit, it jumps to the right of the second digit.  I couldn't see a way to control the position of the insertion point in Entry widgets to fix that. 

Edge weight values are limited to 1-99 and are highlighted when invalid entries are created.  When focus leaves an edge weight text entry, it's value is reverted to the internal representation's edge weight (which is always valid).