### PR TITLE
Issue257 Adjaceny matrix in Windows

### DIFF
--- a/PythonVisualizations/Graph.py
+++ b/PythonVisualizations/Graph.py
@@ -1307,30 +1307,6 @@ def degree(self, n={nVal}):
             
 if __name__ == '__main__':
     graph = Graph(weighted=False)
-    edgePattern = re.compile(r'(\w+)-(\w+)')
-
-    edges = []
-    for arg in sys.argv[1:]:
-        edgeMatch = edgePattern.fullmatch(arg)
-        if len(arg) > 1 and arg[0] == '-':
-            if arg == '-d':
-                graph.DEBUG = True
-            elif arg == '-b':
-                graph.bidirectionalEdges.set(1)
-            elif arg == '-B':
-                graph.bidirectionalEdges.set(0)
-            elif arg[1:].isdigit():
-                graph.setArgument(arg[1:])
-                graph.randomFillButton.invoke()
-                graph.setArgument(
-                    chr(ord(graph.DEFAULT_VERTEX_LABEL) + int(arg[1:])))
-        elif edgeMatch and all(edgeMatch.group(i) in sys.argv[1:] 
-                               for i in (1, 2)):
-            edges.append((edgeMatch.group(1), edgeMatch.group(2)))
-        else:
-            graph.setArgument(arg)
-            graph.newVertexButton.invoke()
-    for fromVert, toVert in edges:
-        graph.createEdge(fromVert, toVert, 1)
+    graph.process_command_line_arguments(sys.argv[1:])
         
     graph.runVisualization()

--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -61,7 +61,7 @@ class GraphBase(VisualizationApp):
         self.window.bind('<Configure>', self.reconfigureHandler())
         mapHandler = self.mapHandler()
         for event in ('<Map>', '<Unmap>'):
-            self.window.bind(event, mapHandler)
+            self.window.bind(event, mapHandler, '+')
     
     def __str__(self):
         verts = self.nVertices()
@@ -80,6 +80,11 @@ class GraphBase(VisualizationApp):
     def mapHandler(self):
         def map_handler(event):
             if event.widget == self.window:
+                if self.DEBUG:
+                    print('{} event on {}'.format(event.type, self.window),
+                          'Adjacency matrix panel = {} state = {}'.format(
+                        self.adjacencyMatrixPanel,
+                        self.adjacencyMatrixPanel.state()))
                 if event.type == EventType.Map:
                     self.adjacencyMatrixPanel.deiconify()
                     self.positionAdjacencyMatrix()
@@ -116,7 +121,7 @@ class GraphBase(VisualizationApp):
             self.adjacencyMatrixPanel, bg=self.ADJACENCY_MATRIX_BG)
         self.adjMatrixFrame.pack(side=TOP, expand=FALSE, fill=None)
 
-        if not (isinstance(self.window, Toplevel) and
+        if not (isinstance(self.window, (Tk, Toplevel)) and
                 sys.platform.startswith('win')):
             # Using the controlPanel rather than the top level window helps
             self.adjacencyMatrixPanel.transient(self.controlPanel)
@@ -125,6 +130,9 @@ class GraphBase(VisualizationApp):
             self.positionAdjacencyMatrix(anchor=anchor)
         else:                              # otherwise hide until it is exposed
             self.adjacencyMatrixAnchor = anchor
+            if self.DEBUG:
+                print('Withdrawing adjacency matrix until {} exposed'.format(
+                    self.window))
             self.adjacencyMatrixPanel.withdraw()
 
     def createAdjacencyMatrixControlImages(self, height=None):
@@ -179,6 +187,11 @@ class GraphBase(VisualizationApp):
         # val attribute is the vertex label pair
         self.edges = {}
 
+        if self.DEBUG:
+            for event in ('Expose', 'Visibility', 'Configure', 'Enter',
+                          'Leave', 'Button'):
+                self.window.bind(
+                    '<{}>'.format(event), genericEventHandler(), '+')
         for cell in self.adjMatrixFrame.grid_slaves():
             cell.grid_forget()
         self.adjMatrix00 = Frame(self.adjMatrixFrame, bg='white')

--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -58,7 +58,7 @@ class GraphBase(VisualizationApp):
         self.createAdjacencyMatrixPanel()
         self.buttons = self.makeButtons()
         self.newGraph()
-        self.window.bind('<Configure>', self.reconfigureHandler())
+        self.window.bind('<Configure>', self.reconfigureHandler(), '+')
         mapHandler = self.mapHandler()
         for event in ('<Map>', '<Unmap>'):
             self.window.bind(event, mapHandler, '+')
@@ -159,6 +159,17 @@ class GraphBase(VisualizationApp):
         if anchor is None: anchor = self.adjacencyMatrixAnchor
         self.adjacencyMatrixAnchor = anchor
         self.window.update_idletasks()
+        if self.DEBUG:
+            print('Repositioning adjacency matrix',
+                  'panel {} state = {}'.format(
+                      self.adjacencyMatrixPanel,
+                      self.adjacencyMatrixPanel.state()),
+                  'App window {} state = {}'.format(
+                      self.window, self.window.state()))
+        if (self.window.state() == NORMAL and
+            sys.platform.startswith('win') or
+            self.adjacencyMatrixPanel.state() != NORMAL):
+            self.adjacencyMatrixPanel.deiconify()
         shown = (
             self.adjMatrixFrame
             if self.adjMatrixFrame in self.adjacencyMatrixPanel.pack_slaves()

--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -166,10 +166,20 @@ class GraphBase(VisualizationApp):
                       self.adjacencyMatrixPanel.state()),
                   'App window {} state = {}'.format(
                       self.window, self.window.state()))
-        if (self.window.state() == NORMAL and
-            sys.platform.startswith('win') or
-            self.adjacencyMatrixPanel.state() != NORMAL):
-            self.adjacencyMatrixPanel.deiconify()
+        if self.window.state() == NORMAL:
+            if not (hasattr(self.adjacencyMatrixPanel, 'trans_parent') and
+                    self.adjacencyMatrixPanel.winfo_geometry().endswith(
+                        '+0+0')):
+                if self.DEBUG:
+                    print('Setting trans_parent of adj mat panel',
+                          self.adjacencyMatrixPanel, 'with geometry',
+                          self.adjacencyMatrixPanel.winfo_geometry())
+                self.adjacencyMatrixPanel.transient(self.controlPanel)
+                setattr(self.adjacencyMatrixPanel, 'trans_parent',
+                        self.controlPanel)
+            if (sys.platform.startswith('win') or
+                self.adjacencyMatrixPanel.state() != NORMAL): 
+                self.adjacencyMatrixPanel.deiconify()
         shown = (
             self.adjMatrixFrame
             if self.adjMatrixFrame in self.adjacencyMatrixPanel.pack_slaves()

--- a/PythonVisualizations/WeightedGraph.py
+++ b/PythonVisualizations/WeightedGraph.py
@@ -911,42 +911,6 @@ def shortestPath(self, start={startVal}, end={endVal}):
             
 if __name__ == '__main__':
     graph = WeightedGraph()
-    edgePattern = re.compile(r'(\w+)-(\w+)(:([1-9][0-9]?))?')
-
-    edges = []
-    for arg in sys.argv[1:]:
-        edgeMatch = edgePattern.fullmatch(arg)
-        if len(arg) > 1 and arg[0] == '-':
-            if arg == '-d':
-                graph.DEBUG = True
-            elif arg[1:].isdigit():
-                graph.setArgument(arg[1:])
-                graph.randomFillButton.invoke()
-                graph.setArgument(
-                    chr(ord(graph.DEFAULT_VERTEX_LABEL) + int(arg[1:])))
-            elif arg in ('-TuralaMST', '-TuralaSP'):  # Examples from textbook
-                for vert in ('Bl', 'Ce', 'Da', 'Gr', 'Ka', 'Na'):
-                    graph.setArgument(vert)
-                    graph.newVertexButton.invoke()
-                for edge in (
-                        ('Bl-Ce:31', 'Bl-Da:24', 'Ce-Da:35', 'Ce-Gr:49',
-                         'Ce-Na:87', 'Ce-Ka:38', 'Da-Gr:41', 'Da-Ka:52',
-                         'Gr-Ka:25', 'Gr-Na:46', 'Ka-Na:43')
-                        if arg == '-TuralaMST' else
-                        ('Bl-Ce:22', 'Bl-Da:16', 'Ce-Da:29', 'Ce-Gr:34',
-                         'Ce-Na:65', 'Ce-Ka:26', 'Da-Gr:28', 'Da-Ka:24',
-                         'Gr-Ka:25', 'Gr-Na:30', 'Ka-Na:36')):
-                    edgeMatch = edgePattern.fullmatch(edge)
-                    graph.createEdge(edgeMatch.group(1), edgeMatch.group(2),
-                                     int(edgeMatch.group(4)))
-        elif edgeMatch and all(edgeMatch.group(i) in sys.argv[1:] 
-                               for i in (1, 2)):
-            edges.append((edgeMatch.group(1), edgeMatch.group(2),
-                          int(edgeMatch.group(4)) if edgeMatch.group(4) else 1))
-        else:
-            graph.setArgument(arg)
-            graph.newVertexButton.invoke()
-    for fromVert, toVert, weight in edges:
-        graph.createEdge(fromVert, toVert, weight)
+    graph.process_command_line_arguments(sys.argv[1:])
         
     graph.runVisualization()

--- a/PythonVisualizations/runAllVisualizations.py
+++ b/PythonVisualizations/runAllVisualizations.py
@@ -52,7 +52,7 @@ boxes and use the soft keyboard to enter values.
 
 def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
         classes, start=None, title="Algorithm Visualizations", 
-        adjustForTrinket=False, seed='3.14159', verbose=0):
+        adjustForTrinket=False, seed='3.14159', verbose=0, debug=False):
     if len(classes) == 0:
         print('No matching classes to visualize', file=sys.stderr)
         return
@@ -109,6 +109,7 @@ def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
             appNumber += 1
             try:
                 vizApp = app(window=pane)
+                vizApp.DEBUG = debug
                 name = getattr(vizApp, 'title', app.__name__)
                 pane.bind('<Map>', oneTimeShowHintHandler(vizApp), '+')
 
@@ -170,6 +171,9 @@ if __name__ == '__main__':
         help='Random number generator seed.  Set to empty string to skip '
         'seeding.')
     parser.add_argument(
+        '-d', '--debug', default=False, action='store_true',
+        help='Show debugging information.')
+    parser.add_argument(
         '-v', '--verbose', action='count', default=0,
         help='Add verbose comments')
     args = parser.parse_args()
@@ -190,5 +194,5 @@ if __name__ == '__main__':
         args.files = list(dirs)
     showVisualizations(findVisualizations(args.files, args.verbose),
                        start=args.start, title=args.title, verbose=args.verbose,
-                       adjustForTrinket=args.warn_for_trinket,
+                       adjustForTrinket=args.warn_for_trinket, debug=args.debug,
                        seed=args.seed)

--- a/PythonVisualizations/runAllVisualizationsMenu.py
+++ b/PythonVisualizations/runAllVisualizationsMenu.py
@@ -112,7 +112,7 @@ def genericEventHandler(event):
         
 def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
         classes, start=None, title="Algorithm Visualizations", 
-        adjustForTrinket=False, seed='3.14159', verbose=0):
+        adjustForTrinket=False, seed='3.14159', verbose=0, debug=False):
     if len(classes) == 0:
         print('No matching classes to visualize', file=sys.stderr)
         return
@@ -187,6 +187,7 @@ def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
             appWindows.append(pane)
             try:
                 vizApp = app(window=pane)
+                vizApp.DEBUG = debug
                 appTitle = getattr(vizApp, 'title', app.__name__)
                 name = folder + ': ' + appTitle
                 setattr(pane, 'appTitle', appTitle)
@@ -252,10 +253,13 @@ if __name__ == '__main__':
         help='Random number generator seed.  Set to empty string to skip '
         'seeding.')
     parser.add_argument(
+        '-d', '--debug', default=False, action='store_true',
+        help='Show debugging information.')
+    parser.add_argument(
         '-v', '--verbose', action='count', default=0,
         help='Add verbose comments')
     args = parser.parse_args()
-        
+
     if args.files is None or args.files == []:
         dirs = set([os.path.relpath(os.getcwd())])
         if (sys.argv and os.path.exists(sys.argv[0]) and
@@ -272,5 +276,5 @@ if __name__ == '__main__':
         args.files = list(dirs)
     showVisualizations(findVisualizations(args.files, args.verbose),
                        start=args.start, title=args.title, verbose=args.verbose,
-                       adjustForTrinket=args.warn_for_trinket,
+                       adjustForTrinket=args.warn_for_trinket, debug=args.debug,
                        seed=args.seed)


### PR DESCRIPTION
This PR should close #257 by restoring the adjacency matrix after Windows hides it.  It also sets the transient relationship between the adjacency matrix and the main window, but only after it has be positioned correctly with respect to it.

This also fixes another bug where the button state after processing command line arguments was incorrect.