### PR TITLE
Tweak canvas width when scrollbars are present

### DIFF
--- a/PythonVisualizations/Visualization.py
+++ b/PythonVisualizations/Visualization.py
@@ -70,8 +70,8 @@ class Visualization(object):  # Base class for Python visualizations
         if canvasBounds:
             self.canvasVScroll = Scrollbar(self.canvasFrame, orient=VERTICAL)
             self.canvasVScroll.pack(side=RIGHT, expand=False, fill=Y)
-            if canvasWidth == 800:  # For Trinket, shrink canvas width to show
-                self.targetCanvasWidth, canvasWidth = 788, 788 # scrollbar
+            if canvasWidth == 800:  # Shrink canvas width to show scrollbar
+                self.targetCanvasWidth, canvasWidth = 785, 785
         else:
             self.canvasVScroll = None
         self.canvas = Scrim(


### PR DESCRIPTION
This PR should close #240 by adjusting the canvas width when scrollbars are present.  It makes the adjustment regardless of whether the program is configured for the Trinket environment or otherwise.