### PR TITLE
Issue276 Align and convert to OutputBox

### DIFF
--- a/PythonVisualizations/BinaryTree.py
+++ b/PythonVisualizations/BinaryTree.py
@@ -62,7 +62,7 @@ def delete(self, goal={goal}):
             outBoxCoords = self.outputBoxCoords(font=self.outputFont, N=1)
             outBox = self.createOutputBox(coords=outBoxCoords)
             callEnviron |= set(outBox.items())
-            outBoxCenter = V(V(outBoxCoords[:2]) + V(outBoxCoords[2:])) // 2
+            outBoxCenter = BBoxCenter(outBoxCoords)
 
             result = self.canvas.itemConfig(deletedKeyAndData[1], 'text')
             outBox.setToText(deletedKeyAndData, color=True, sleepTime=wait / 10)

--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -1118,12 +1118,9 @@ for key, data in tree.traverse("{traverseType}"):
         
         outBoxCoords = self.outputBoxCoords(font=self.outputFont)
         outBoxMidY = (outBoxCoords[1] + outBoxCoords[3]) // 2
-        outputBox = self.createOutputBox(coords=outBoxCoords)
-        callEnviron.add(outputBox)
-        outputText = self.canvas.create_text(
-            outBoxCoords[0] + 5, outBoxMidY, text='', anchor=W, 
-            font=self.outputFont)
-        callEnviron.add(outputText)
+        outputBox = self.createOutputBox(
+            coords=outBoxCoords, outputOffset=(5, 10))
+        callEnviron |= set(outputBox.items())
         
         iteratorCall = 'key, data in tree.traverse("{traverseType}")'.format(
             **locals())
@@ -1147,17 +1144,7 @@ for key, data in tree.traverse("{traverseType}"):
             self.highlightCode('print(key)', callEnviron, wait=wait)
             keyItem = self.canvas.copyItem(items[2])
             callEnviron.add(keyItem)
-            currentText = self.canvas.itemConfig(outputText, 'text')
-            textBBox = self.canvas.bbox(outputText)
-            newTextWidth = textWidth(self.outputFont, ' ' + str(key))
-            self.moveItemsTo(
-                keyItem, (textBBox[2] + newTextWidth // 2, outBoxMidY),
-                sleepTime=wait / 10)
-            self.canvas.itemConfig(
-                outputText,
-                text=currentText + (' ' if len(currentText) > 0 else '') +
-                str(key))
-            self.canvas.delete(keyItem)
+            outputBox.appendText(keyItem, sleepTime=wait / 10)
             callEnviron.discard(keyItem)
 
             self.highlightCode(iteratorCall, callEnviron, wait=wait)

--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -6,12 +6,16 @@ try:
     from coordinates import *
     from drawnValue import *
     from tkUtilities import *
+    from Signatures import *
     from VisualizationApp import *
+    from OutputBox import *
 except ModuleNotFoundError:
     from .coordinates import *
     from .drawnValue import *
     from .tkUtilities import *
+    from .Signatures import *
     from .VisualizationApp import *
+    from .OutputBox import *
 
 V = vector
 
@@ -592,9 +596,14 @@ class BinaryTreeBase(VisualizationApp):
         return (left, canvasDims[1] - height - padding,
                 left + width, canvasDims[1] - padding)
 
-    def createOutputBox(self, coords=None, font=None):
-        if coords is None: coords = self.outputBoxCoords(font=font)
-        return self.canvas.create_rectangle(*coords, fill=self.OPERATIONS_BG)
+    def createOutputBox(self, coords=None, font=None, **kwargs):
+        if coords is None:
+            config = dict((k, kwargs[k])
+                          for k in keywordParameters(outputBoxCoords)
+                          if k in kwargs)
+            config[font] = font
+            coords = self.outputBoxCoords(**config)
+        return OutputBox(self, coords, **kwargs)
         
     def cleanUp(self, *args, **kwargs):
         '''Customize cleanUp to restore nodes when call stack is empty'''

--- a/PythonVisualizations/Heap.py
+++ b/PythonVisualizations/Heap.py
@@ -6,7 +6,6 @@ try:
     from coordinates import *
     from BinaryTreeBase import *
     from TableDisplay import *
-    from OutputBox import *
 except ModuleNotFoundError:
     from .drawnValue import *
     from .coordinates import *

--- a/PythonVisualizations/RedBlackTree.py
+++ b/PythonVisualizations/RedBlackTree.py
@@ -584,20 +584,15 @@ class RedBlackTree(BinaryTreeBase):
             deletedKeyAndData = self.__delete(parent, node)
             callEnviron |= set(deletedKeyAndData)
             self.canvas.restoreItems(localVars, colors)
+            result = self.canvas.itemConfig(deletedKeyAndData[1], 'text')
 
             outBoxCoords = self.outputBoxCoords(font=self.outputFont, N=1)
             outBox = self.createOutputBox(coords=outBoxCoords)
-            callEnviron.add(outBox)
-            outBoxCenter = V(V(outBoxCoords[:2]) + V(outBoxCoords[2:])) // 2
+            callEnviron |= set(outBox.items())
+            outBoxCenter = BBoxCenter(outBoxCoords)
 
-            self.canvas.tag_raise(deletedKeyAndData[1], outBox)
-            for j in (2, 0):
-                self.canvas.tag_lower(deletedKeyAndData[j], outBox)
-            self.moveItemsTo(
-                deletedKeyAndData, self.nodeItemCoords(outBoxCenter)[1:],
-                sleepTime=wait / 10)
-            self.canvas.copyItemAttributes(deletedKeyAndData[0], outBox, 'fill')
-            self.dispose(callEnviron, deletedKeyAndData[0], deletedKeyAndData[2])
+            outBox.setToText(deletedKeyAndData, color=True, sleepTime=wait / 10)
+            callEnviron -= set(deletedKeyAndData)
 
             if self.getNode(node):
                 if node % 2 == 1:
@@ -605,12 +600,11 @@ class RedBlackTree(BinaryTreeBase):
                 self.moveItemsBy(
                     nodeIndex, (0, - self.LEVEL_GAP // 3), sleepTime=wait / 10)
         else:
-            deletedKeyAndData = None
+            result = None
 
         self.cleanUp(callEnviron)
-        return (self.canvas.itemConfig(deletedKeyAndData[1], 'text')
-                if deletedKeyAndData else None)
-    
+        return result
+
     def __delete(self, parent, node, level=1):
         'parent and node must be integer indices'
         wait = 0.1


### PR DESCRIPTION
This PR should close #276 and close #273 by converting BinaryTreeBase to create an OutputBox for traversal, deletion, and peek outputs.  It aligns the center of the output box with the tree root's center so that it looks better in the Heap display.
The AVLTree visualization app uses its own methods for managing the output box.
It also fixes a bug where deleting a node in binary tree that has two child nodes would not correctly replace the deleted node with its successor.