### PR TITLE
Issue282 Fix Tree234 traverse item positions during zoom

### DIFF
--- a/PythonVisualizations/GraphBase.py
+++ b/PythonVisualizations/GraphBase.py
@@ -1180,12 +1180,14 @@ class GraphBase(VisualizationApp):
                              'Ce-Na:65', 'Ce-Ka:26', 'Da-Gr:28', 'Da-Ka:24',
                              'Gr-Ka:25', 'Gr-Na:30', 'Ka-Na:36')):
                         edgeMatch = edgePattern.fullmatch(edge)
-                        self.createEdge(edgeMatch.group(1), edgeMatch.group(2),
-                                         int(edgeMatch.group(4)))
+                        self.createEdge(
+                            edgeMatch.group(1), edgeMatch.group(2),
+                            int(edgeMatch.group(4)) if self.weighted else 1)
             elif edgeMatch and all(
                     edgeMatch.group(i) in argv for i in (1, 2)):
                 edges.append((edgeMatch.group(1), edgeMatch.group(2),
-                              int(edgeMatch.group(4)) if edgeMatch.group(4)
+                              int(edgeMatch.group(4))
+                              if self.weighted and edgeMatch.group(4)
                               else 1))
             elif len(arg) > 0:
                 self.setArgument(arg)

--- a/PythonVisualizations/HashTableChaining.py
+++ b/PythonVisualizations/HashTableChaining.py
@@ -614,7 +614,7 @@ def traverse(self):
 
     def randomFill(
             self, nItems, animate=None, alphabet=
-            'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ-_+.,&/:'):
+            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_+&:'):
         if animate is None: animate = self.showHashing.get()
         callEnviron = self.createCallEnvironment()
         count = 0

--- a/PythonVisualizations/HashTableChaining.py
+++ b/PythonVisualizations/HashTableChaining.py
@@ -1231,7 +1231,9 @@ if __name__ == '__main__':
     showHashing = hashTable.showHashing.get()
     hashTable.showHashing.set(1 if animate else 0)
     for arg in sys.argv[1:]:
-        if not(arg[0] == '-' and len(arg) == 2 and arg[1:].isalpha()):
+        if arg.startswith('-') and arg[1:].isdigit():
+            hashTable.randomFill(int(arg[1:]))
+        elif not(arg[0] == '-' and len(arg) == 2 and arg[1:].isalpha()):
             if animate:
                 hashTable.setArgument(arg)
                 hashTable.insertButton.invoke()


### PR DESCRIPTION
This PR closes issue #282 by only allowing zoom changes when the application is paused and better management of the position of the traverse stack and related variables on the canvas.

It also improves the command line options for the hash table and graph visualization apps.