### PR TITLE
Issue296 Fix quicksort failure

### DIFF
--- a/PythonVisualizations/SortingBase.py
+++ b/PythonVisualizations/SortingBase.py
@@ -143,8 +143,8 @@ class SortingBase(VisualizationApp):
         startAngle = 45 * 500 / (500 + abs(deltaX)) * (-1 if deltaX < 0 else 1)
 
         self.moveItemsOnCurve(
-            temp.items, (toCellCoords, toCellCenter), sleepTime=sleepTime,
-            startAngle=startAngle)
+            temp.items, (toCellCoords, toCellCenter)[:len(temp.items)],
+            sleepTime=sleepTime, startAngle=startAngle)
 
         if delete:
             if templabel:


### PR DESCRIPTION
This PR should close #296 by adjusting `assignFromTemp` to correctly handle movement of items from the temporary variable back to the array when item keys are not being shown.