### PR TITLE
Issue291 Delete nodes rotated beyond level 4

### DIFF
--- a/PythonVisualizations/AVLTree.py
+++ b/PythonVisualizations/AVLTree.py
@@ -403,8 +403,8 @@ def rotateLeft(self, top={topKey}):
         toRaiseLeftTree = self.getNodeTree(toRaiseLeft, erase=True)
         toRaiseRightTree = self.getNodeTree(toRaiseRight, erase=True)
 
-        # Move nodes internally
-        self.storeNodeTree(
+        # Move nodes internally, noting any nodes cutoff past depth limit
+        cutoff = self.storeNodeTree(
             [toRaiseNode, 
              [topNode, topLeftTree, toRaiseLeftTree], toRaiseRightTree],
             topIndex)
@@ -413,10 +413,10 @@ def rotateLeft(self, top={topKey}):
         # Move canvas items to new positions to match internal structure
         newSubTree = self.getAllDescendants(topIndex)
         newSubTreeItems = flat(*(
-            node.drawnValue.items for node in newSubTree))[1:]
+            node.drawnValue.items for node in newSubTree + list(cutoff)))[1:]
         toPositions = flat(*(
             self.nodeItemCoords(node, parent=self.getParent(node)) 
-            for node in newSubTree))[1:]
+            for node in newSubTree + [len(self.nodes) * 3] * len(cutoff)))[1:]
         if animation:
             self.moveItemsLinearly(
                 newSubTreeItems + topArrow + toRaiseArrow, 
@@ -425,6 +425,14 @@ def rotateLeft(self, top={topKey}):
         else:
             for item, coords in zip(newSubTreeItems, toPositions):
                 self.canvas.coords(item, *coords)
+        if cutoff and animation:
+            self.setMessage(
+                'Removed node{} {} that went beyond level {}'.format(
+                    '' if len(cutoff) == 1 else 's',
+                    ', '.join(str(node.getKey()) for node in cutoff),
+                self.MAX_LEVEL - 1))
+        self.dispose(callEnviron,
+                     *flat(*(node.drawnValue.items for node in cutoff)))
                 
         # Update heights of rotated nodes
         if animation:
@@ -497,8 +505,8 @@ def rotateRight(self, top={topKey}):
         toRaiseRightTree = self.getNodeTree(toRaiseRight, erase=True)
         toRaiseLeftTree = self.getNodeTree(toRaiseLeft, erase=True)
 
-        # Move the subtrees internally
-        self.storeNodeTree(
+        # Move nodes internally, noting any nodes cutoff past depth limit
+        cutoff = self.storeNodeTree(
             [toRaiseNode,
              toRaiseLeftTree, [topNode, toRaiseRightTree, topRightTree]],
             topIndex)
@@ -507,10 +515,10 @@ def rotateRight(self, top={topKey}):
         # Move canvas items to new positions to match internal structure
         newSubTree = self.getAllDescendants(topIndex)
         newSubTreeItems = flat(*(
-            node.drawnValue.items for node in newSubTree))[1:]
+            node.drawnValue.items for node in newSubTree + list(cutoff)))[1:]
         toPositions = flat(*(
             self.nodeItemCoords(node, parent=self.getParent(node)) 
-            for node in newSubTree))[1:]
+            for node in newSubTree + [len(self.nodes) * 3] * len(cutoff)))[1:]
         if animation:
             self.moveItemsLinearly(
                 newSubTreeItems + topArrow + toRaiseArrow, 
@@ -519,6 +527,14 @@ def rotateRight(self, top={topKey}):
         else:
             for item, coords in zip(newSubTreeItems, toPositions):
                 self.canvas.coords(item, *coords)
+        if cutoff and animation:
+            self.setMessage(
+                'Removed node{} {} that went beyond level {}'.format(
+                    '' if len(cutoff) == 1 else 's',
+                    ', '.join(str(node.getKey()) for node in cutoff),
+                self.MAX_LEVEL - 1))
+        self.dispose(callEnviron,
+                     *flat(*(node.drawnValue.items for node in cutoff)))
                 
         # Update heights of rotated nodes
         if animation:

--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -276,7 +276,7 @@ class BinaryTreeBase(VisualizationApp):
             nodeTree: 'Subtree in the form of a nested list of nodes',
             index: 'Index to place top of subtree',
             updateCenter:'Update center coords for new position' =True
-    ) -> 'Returns tuple of nodes that could not be stored (below depth limit)' :
+    ) -> 'Returns tuple of nodes that could not be stored (past depth limit)':
 
         empty = (nodeTree is None or len(nodeTree) != 3 or
                  not isinstance(nodeTree[0], Node)) # Is this an empty node?
@@ -770,11 +770,14 @@ class BinaryTreeBase(VisualizationApp):
             return self.setRightChild(parent, child, updateLink=updateLink)
 
     def replaceSubtree(
-            self, nodeIndex, leftOrRight, replacementIndex, callEnviron,
-            wait=0.1):
-        '''Move the subtree at replacementIndex to be the left or right
-        child of the node at nodeIndex. Discard the current subtree of
-        that node.  Animate the process by moving leftOrRight child link
+            self: 'Move a subtree to be the left or right child of a node',
+            nodeIndex: 'Node index to get new child subtree',
+            leftOrRight: 'Side of node to receive new subtree',
+            replacementIndex: 'Source subtree index',
+            callEnviron: 'Animation environment',
+            wait: 'Wait time between animation steps' =0.1
+    ) -> 'Returns tuple of nodes that could not be stored (past depth limit)':
+        '''Animate the process by moving leftOrRight child link
         first (when nodeIndex points at an existing node) and then the
         nodes in the subtrees'''
         childIndex = self.getChildIndex(nodeIndex, leftOrRight)
@@ -809,15 +812,20 @@ class BinaryTreeBase(VisualizationApp):
                     self.removeNodeDrawing(node)
                     self.removeNodeInternal(node)
 
-        self.moveSubtree(childIndex, replacementIndex)
+        cutoff = self.moveSubtree(childIndex, replacementIndex)
         self.restoreNodePositions(replacementNodes, sleepTime=wait /10)
+        return cutoff
         
-    def moveSubtree(self, toIndex, fromIndex):
-        "Move internal subtree rooted at fromIndex to be rooted at toIndex"
+    def moveSubtree(
+            self: 'Move internal subtree from one place to another',
+            toIndex: 'Destination subtree root',
+            fromIndex: 'Source subtree root'
+    ) -> 'Returns tuple of nodes that could not be stored (past depth limit)':
         if toIndex < 0 or len(self.nodes) <= toIndex or toIndex == fromIndex:
-            return    # Do nothing if the to index is out of bounds or = from
+            return ()  # Do nothing if the to index is out of bounds or = from
 
-        self.storeNodeTree(self.getNodeTree(fromIndex, erase=True), toIndex)
+        return self.storeNodeTree(self.getNodeTree(fromIndex, erase=True),
+                                  toIndex)
 
     def generateTag(self):
         self.prevId+=1

--- a/PythonVisualizations/BinaryTreeBase.py
+++ b/PythonVisualizations/BinaryTreeBase.py
@@ -64,6 +64,8 @@ class BinaryTreeBase(VisualizationApp):
     STACK_DEFAULT_SIZE = (100, None)
     NONE_DOT_RADIUS = 2
     NONE_DOT_COLOR = 'red'
+    DEPTH_BOUNDARY_COLOR = 'gray80'
+    DEPTH_BOUNDARY_DASH = (5, 10)
 
     def __init__(self, RECT=None, CIRCLE_SIZE=None, VAL_MAX=valMax, 
                ARROW_HEIGHT=None, MAX_LEVEL=None, **kwargs):
@@ -269,19 +271,26 @@ class BinaryTreeBase(VisualizationApp):
                 self.getNodeTree(self.getRightChildIndex(nodeIndex),
                                  erase=erase)]
 
-    def storeNodeTree(self, nodeTree, index, updateCenter=True):
-        '''Place nodes from a nested list [sub-]tree into the nodes array 
-        starting at a given index.  Put None in any cells past leaves'''
-        if len(self.nodes) <= index:  # Beyond storage limit, nothing to store
-            return
-        if nodeTree is None or len(nodeTree) != 3:  # Empty node, store None
-            self.nodes[index] = None
-            return
-        self.nodes[index] = nodeTree[0]  # Store node at index and its subtrees
-        if updateCenter:
-            self.nodes[index].center = self.nodeCenter(index)
-        self.storeNodeTree(nodeTree[1], self.getLeftChildIndex(index))
-        self.storeNodeTree(nodeTree[2], self.getRightChildIndex(index))
+    def storeNodeTree(
+            self: 'Place nodes from a [sub-]tree into the nodes array ',
+            nodeTree: 'Subtree in the form of a nested list of nodes',
+            index: 'Index to place top of subtree',
+            updateCenter:'Update center coords for new position' =True
+    ) -> 'Returns tuple of nodes that could not be stored (below depth limit)' :
+
+        empty = (nodeTree is None or len(nodeTree) != 3 or
+                 not isinstance(nodeTree[0], Node)) # Is this an empty node?
+        cutoff = ((nodeTree[0],)              # Cutoff non-empty nodes
+                  if not empty and len(self.nodes) <= index else  # Beyond limit
+                  ())  # otherwise nothing to cutoff
+        if index < len(self.nodes): # Store node at index if valid
+            self.nodes[index] = None if empty else nodeTree[0]
+            if updateCenter and self.nodes[index]: # Update center if requested
+                self.nodes[index].center = self.nodeCenter(index)
+        return cutoff if empty else (
+            cutoff +
+            self.storeNodeTree(nodeTree[1], self.getLeftChildIndex(index)) +
+            self.storeNodeTree(nodeTree[2], self.getRightChildIndex(index)))
 
     # ----------- DRAWING METHODS -------------------
    
@@ -852,6 +861,11 @@ class BinaryTreeBase(VisualizationApp):
                     for i, node in enumerate(self.nodes)]
         self.nodes = newNodes
         self.size = sum(1 if node else 0 for node in self.nodes)
+        depthBoundary = (self.nodeCenter(len(self.nodes) + 1) +
+                         self.nodeCenter(len(self.nodes) * 2))
+        self.canvas.create_line(
+            *depthBoundary, fill=self.DEPTH_BOUNDARY_COLOR,
+            dash=self.DEPTH_BOUNDARY_DASH, tags='boundary')
         
     # remove the node's drawing and optionally its line
     def removeNodeDrawing(self, node, line=False):


### PR DESCRIPTION
This PR should close #291 by changing the BinaryTreeBase to record nodes that are moved out of the array during a subtree move.  This only causes a display problem for Red-Black trees where arbitrary rotations can be peformed.  While AVL trees also make rotations, they never do it in a way that pushes an existing vertex to level 5 (since insertion doesn't allow inserting at level 5 and the tree is always balanced.)