### PR TITLE
Issue295 Prevent edges from obscuring graph vertices

### DIFF
--- a/PythonVisualizations/RedBlackTree.py
+++ b/PythonVisualizations/RedBlackTree.py
@@ -151,6 +151,7 @@ class RedBlackTree(BinaryTreeBase):
                 if self.DEBUG:
                     print('Flipped', node, 'color to', self.nodeColor(nodeIndex))
             self.operationMutex.release()
+            self.enableButtons()
         return flipHandler
 
     def rotateNode(self, key):

--- a/PythonVisualizations/VisualizationApp.py
+++ b/PythonVisualizations/VisualizationApp.py
@@ -538,14 +538,8 @@ class VisualizationApp(Visualization): # Base class for visualization apps
         self.textEntries[index].configure(bg=color)
             
     def argumentChanged(self, widget=None):
-        args = self.getArguments()
-        withArgs, withoutArgs = self.getOperations()
-        for button in withArgs:
-            nArgs = getattr(button, 'required_args')
-            widgetState(
-                button,
-                DISABLED if not self.animationsStopped() or any(
-                    arg == '' for arg in args[:nArgs]) else NORMAL)
+        # Enable buttons if animations are stopped
+        self.enableButtons(self.animationsStopped())
 
         for i, entry in enumerate(self.textEntries):
             if widget == entry:  # For the entry widget that changed,

--- a/PythonVisualizations/runAllVisualizations.py
+++ b/PythonVisualizations/runAllVisualizations.py
@@ -98,7 +98,9 @@ def showVisualizations(   # Display a set of VisualizationApps in a ttk.Notebook
         fields = set(('width', 'height'))
         intro.bind('<Configure>', genericEventHandler(fields=fields), '+')
     notebook.pack(expand=True, fill=BOTH)
-    notebook.wait_visibility(top)
+    
+    # Waiting here for notebook visibility sometimes hangs
+    # notebook.wait_visibility(top)  
                
     classes_dict = dict((app.__name__, app) for app in classes)
     ordered_classes = [


### PR DESCRIPTION
This PR should close #295 by keeping vertices above all edges including the highlighted edge during minimum-spanning tree animation.

It also provides a couple other minor fixes:

 - After changes to the arguments in the text entry boxes, VisualizationApp now calls `enableButtons()` to reenable buttons.  This means special logic correctly disables buttons that can't be used (like adding more vertices to a graph that already has the maximum).
 - Prevent a hang in runAllVisualizations (that may only occur in newer tkinter versions)